### PR TITLE
Fixed typo & added `npm install` step

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,10 @@ https://www.pastebar.app
 * **Rust**: Tauri Apps, Diesel ORM, Reqwest, Anyhow, Serde, Tokio.
 * **Javascript**: Typescript, React, React Query, Vite, TailwindCSS, Signals, Jotai, Zustand.
 
-# Build Local PastBar App
+# Build Local PasteBar App
 
 ```
+$ npm install
 $ npm run build
 ```
 


### PR DESCRIPTION
Not much to note here - just added `npm install` to the local build instructions and fixed a typo. Thanks!!