### PR TITLE
Fix custom DB path security issues

### DIFF
--- a/src-tauri/src/services/settings_service.rs
+++ b/src-tauri/src/services/settings_service.rs
@@ -39,7 +39,11 @@ pub fn insert_or_update_setting_by_name(
   setting: &Setting,
   app_handle: tauri::AppHandle,
 ) -> Result<String, Error> {
-  let connection = &mut DB_POOL_CONNECTION.read().unwrap().get().unwrap();
+  let connection = &mut DB_POOL_CONNECTION
+    .read()
+    .expect("Failed to acquire read lock on DB_POOL_CONNECTION")
+    .get()
+    .expect("Failed to get a database connection from the pool");
 
   match settings
     .filter(name.eq(&setting.name))

--- a/src-tauri/src/services/settings_service.rs
+++ b/src-tauri/src/services/settings_service.rs
@@ -39,7 +39,7 @@ pub fn insert_or_update_setting_by_name(
   setting: &Setting,
   app_handle: tauri::AppHandle,
 ) -> Result<String, Error> {
-  let connection = &mut DB_POOL_CONNECTION.get().unwrap();
+  let connection = &mut DB_POOL_CONNECTION.read().unwrap().get().unwrap();
 
   match settings
     .filter(name.eq(&setting.name))


### PR DESCRIPTION
## Summary
- protect against path traversal in `cmd_validate_custom_db_path`
- implement rollback and connection reinitialization when relocating data
- add connection pool reinit helper and use RwLock for dynamic pool
- improve UI error handling with rollback on failure

## Testing
- `cargo fmt --all`
- `npm run format` *(fails: warnings but executed)*

------
https://chatgpt.com/codex/tasks/task_e_684a676f6ee48320aab797b982b152d0