### PR TITLE
Show hide tray icon user preference

### DIFF
--- a/packages/pastebar-app-ui/src/App.tsx
+++ b/packages/pastebar-app-ui/src/App.tsx
@@ -195,6 +195,7 @@ function App() {
           isHistoryPanelVisibleOnly: settings.isHistoryPanelVisibleOnly?.valueBool,
           isSavedClipsPanelVisibleOnly: settings.isSavedClipsPanelVisibleOnly?.valueBool,
           isSimplifiedLayout: settings.isSimplifiedLayout?.valueBool ?? true,
+          showTrayIcon: settings.showTrayIcon?.valueBool ?? true, // Added line
           isAppReady: true,
         })
         settingsStore.initConstants({

--- a/packages/pastebar-app-ui/src/store/settingsStore.ts
+++ b/packages/pastebar-app-ui/src/store/settingsStore.ts
@@ -96,6 +96,7 @@ type Settings = {
   isHistoryPanelVisibleOnly: boolean
   isSavedClipsPanelVisibleOnly: boolean
   isSimplifiedLayout: boolean
+  showTrayIcon: boolean
 }
 
 type Constants = {
@@ -178,6 +179,7 @@ export interface SettingsStoreState {
   setIsSavedClipsPanelVisibleOnly: (isVisible: boolean) => void
   setShowBothPanels: (isVisible: boolean) => void
   setIsSimplifiedLayout: (isEnabled: boolean) => void
+  setShowTrayIcon: (showTrayIcon: boolean) => void
   hashPassword: (pass: string) => Promise<string>
   isNotTourCompletedOrSkipped: (tourName: string) => boolean
   verifyPassword: (pass: string, hash: string) => Promise<boolean>
@@ -269,6 +271,7 @@ const initialState: SettingsStoreState & Settings = {
   isHistoryPanelVisibleOnly: false,
   isSavedClipsPanelVisibleOnly: false,
   isSimplifiedLayout: true,
+  showTrayIcon: true,
   CONST: {
     APP_DETECT_LANGUAGES_SUPPORTED: [],
   },
@@ -333,6 +336,7 @@ const initialState: SettingsStoreState & Settings = {
   setIsSavedClipsPanelVisibleOnly: () => {},
   setShowBothPanels: () => {},
   setIsSimplifiedLayout: () => {},
+  setShowTrayIcon: () => {},
   initConstants: () => {},
   setAppDataDir: () => {}, // Keep if used for other general app data
   setCustomDbPath: () => {},
@@ -697,6 +701,10 @@ export const settingsStore = createStore<SettingsStoreState & Settings>()((set, 
   },
   setIsSimplifiedLayout: async (isEnabled: boolean) => {
     return get().updateSetting('isSimplifiedLayout', isEnabled)
+  },
+  setShowTrayIcon: async (showTrayIcon: boolean) => {
+    // The backend will handle tray visibility on next startup based on this persisted setting.
+    return get().updateSetting('showTrayIcon', showTrayIcon)
   },
   isNotTourCompletedOrSkipped: (tourName: string) => {
     const { appToursCompletedList, appToursSkippedList } = get()


### PR DESCRIPTION
The `showTrayIcon` user preference was not being explicitly passed from the `appReady()` command's results to the `settingsStore.initSettings()` call within `App.tsx`. This could lead to the frontend store not correctly reflecting the persisted value of `showTrayIcon` at startup.

This commit updates `App.tsx` to include `showTrayIcon` in the settings object passed to `initSettings`, ensuring its value is derived from the backend configuration.