### PR TITLE
feat: Add support for notes matching in global search and keyboard navigation enhancements  

### DIFF
--- a/.changeset/warm-beans-look.md
+++ b/.changeset/warm-beans-look.md
@@ -1,0 +1,5 @@
+---
+'pastebar-app-ui': patch
+---
+
+Support for notes matching in global search

--- a/packages/pastebar-app-ui/src/libs/create-filtered-flat-board-tree.ts
+++ b/packages/pastebar-app-ui/src/libs/create-filtered-flat-board-tree.ts
@@ -25,7 +25,11 @@ export default function createFilteredFlatBoardTreeWithClips(
           !isSearchNameOrLabelOnly &&
           item.value?.toLowerCase().includes(find.toLowerCase())
 
-        return nameMatches || valueMatches
+        const descriptionMatches =
+          !isSearchNameOrLabelOnly &&
+          item.description?.toLowerCase().includes(find.toLowerCase())
+
+        return nameMatches || valueMatches || descriptionMatches
       })
       .map(item => ({ ...item, type: CLIP, id: item.itemId.toString() }))
 

--- a/packages/pastebar-app-ui/src/libs/create-filtered-flat-board-tree.ts
+++ b/packages/pastebar-app-ui/src/libs/create-filtered-flat-board-tree.ts
@@ -12,6 +12,9 @@ export default function createFilteredFlatBoardTreeWithClips(
   const findTabById = (tabId: string | undefined) =>
     allTabs.filter(tab => tab.tabId === tabId)
 
+  // Pre-compute lowercase search term
+  const lowerFind = find.toLowerCase()
+
   const findChildrenClips = (parentId: string | null) =>
     items
       .filter(item => {
@@ -19,15 +22,15 @@ export default function createFilteredFlatBoardTreeWithClips(
           return false
         }
 
-        const nameMatches = item.name.toLowerCase().includes(find.toLowerCase())
+        const nameMatches = item.name.toLowerCase().includes(lowerFind)
 
         const valueMatches =
           !isSearchNameOrLabelOnly &&
-          item.value?.toLowerCase().includes(find.toLowerCase())
+          item.value?.toLowerCase().includes(lowerFind)
 
         const descriptionMatches =
           !isSearchNameOrLabelOnly &&
-          item.description?.toLowerCase().includes(find.toLowerCase())
+          item.description?.toLowerCase().includes(lowerFind)
 
         return nameMatches || valueMatches || descriptionMatches
       })
@@ -64,7 +67,7 @@ export default function createFilteredFlatBoardTreeWithClips(
         })
         .filter(board => board !== null)
     : allBoards
-        .filter(board => board.name.toLowerCase().includes(find.toLowerCase()))
+        .filter(board => board.name.toLowerCase().includes(lowerFind))
         .map(board => {
           const children = findAllChildrenClips(board.itemId.toString())
           return {

--- a/packages/pastebar-app-ui/src/pages/components/Dashboard/components/Board.tsx
+++ b/packages/pastebar-app-ui/src/pages/components/Dashboard/components/Board.tsx
@@ -154,7 +154,7 @@ interface BoardProps {
   isDragPreview?: boolean
   keyboardSelectedClipId?: { value: UniqueIdentifier | null }
   currentSelectedBoardId?: { value: UniqueIdentifier | null }
-  keyboardNavigationMode?: { value: 'history' | 'board' | null }
+  keyboardNavigationMode?: { value: 'history' | 'board' | 'search' | null }
 }
 
 export function BoardComponent({
@@ -757,8 +757,7 @@ export function BoardComponent({
                                           selectedItemIds.indexOf(item.id) + 1
                                         }
                                         isKeyboardSelected={
-                                          keyboardSelectedClipId?.value === item.id &&
-                                          keyboardNavigationMode?.value === 'board'
+                                          keyboardSelectedClipId?.value === item.id
                                         }
                                       />
                                     )

--- a/packages/pastebar-app-ui/src/pages/components/Dashboard/components/GlobalSearch.tsx
+++ b/packages/pastebar-app-ui/src/pages/components/Dashboard/components/GlobalSearch.tsx
@@ -1,15 +1,21 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { UniqueIdentifier } from '@dnd-kit/core'
 import { useSignal } from '@preact/signals-react'
 import { Portal } from '@radix-ui/react-portal'
 import createFilteredFlatBoardTree from '~/libs/create-filtered-flat-board-tree'
 import createMenuTree from '~/libs/create-menu-tree'
 import {
   collectionsStoreAtom,
+  currentNavigationContext,
   isNavBarHovering,
+  keyboardSelectedBoardId,
+  keyboardSelectedClipId,
+  keyboardSelectedItemId,
   recentSearchTerm,
   settingsStoreAtom,
   uiStoreAtom,
 } from '~/store'
+import clsx from 'clsx'
 import { useAtomValue } from 'jotai/react'
 import { Search, Settings } from 'lucide-react'
 import { useHotkeys } from 'react-hotkeys-hook'
@@ -62,7 +68,9 @@ export function GlobalSearch({ isDark }: { isDark: boolean }) {
   const { t } = useTranslation()
   const [searchTerm, setSearchTerm] = useState('')
   const [filter, setFilter] = useState<string>(FILTER.CLIPS)
+  const [selectedIndex, setSelectedIndex] = useState<number>(-1)
   const searchHistoryInputRef = useRef<HTMLElement>()
+  const scrollContainerRef = useRef<HTMLDivElement>(null)
   const deletingMenuItemIds = useSignal<string[] | null>(null)
   const showEditMenuItemId = useSignal<string | null>(null)
   const showMultiSelectItems = useSignal(false)
@@ -76,7 +84,7 @@ export function GlobalSearch({ isDark }: { isDark: boolean }) {
     isSearchNameOrLabelOnly,
   } = useAtomValue(settingsStoreAtom)
 
-  const [copiedItem] = useCopyClipItem({})
+  const [copiedItem, handleCopyClipItem] = useCopyClipItem({})
   const [pastedItem] = usePasteClipItem({})
 
   const { clipItems, tabs, setCurrentTab } = useAtomValue(collectionsStoreAtom)
@@ -91,10 +99,22 @@ export function GlobalSearch({ isDark }: { isDark: boolean }) {
 
   const [showSearchModal, setShowSearchModal] = useState(false)
 
+  // Reset all keyboard navigation when search opens
+  const resetKeyboardNavigation = () => {
+    currentNavigationContext.value = null
+    keyboardSelectedItemId.value = null
+    keyboardSelectedClipId.value = null
+    keyboardSelectedBoardId.value = null
+  }
+
   const toggleSearch = (e: Event) => {
     e.preventDefault()
     e.stopPropagation()
-    setShowSearchModal(show => !show)
+    setShowSearchModal(show => {
+      const newShow = !show
+      resetKeyboardNavigation()
+      return newShow
+    })
     searchHistoryInputRef.current?.focus()
   }
 
@@ -224,6 +244,113 @@ export function GlobalSearch({ isDark }: { isDark: boolean }) {
     setShowSearchModal(false)
   }
 
+  // Create flattened item lists for navigation
+  const flattenedItems = useMemo(() => {
+    const clips: Array<{
+      id: UniqueIdentifier
+      type: 'clip'
+      data: any
+      boardIndex: number
+    }> = []
+    const boards: Array<{ id: UniqueIdentifier; type: 'board'; data: any }> = []
+    const menus: Array<{ id: UniqueIdentifier; type: 'menu'; data: any }> = []
+
+    // Flatten clips from all boards
+    clipItemsFiltered.results.forEach((board, boardIndex) => {
+      board.children?.forEach(clip => {
+        clips.push({
+          id: clip.id,
+          type: 'clip',
+          data: clip,
+          boardIndex,
+        })
+      })
+    })
+
+    // Flatten boards
+    boardsFiltered.results.forEach(board => {
+      boards.push({
+        id: board.id,
+        type: 'board',
+        data: board,
+      })
+    })
+
+    // Flatten menus
+    menuItemsFiltered.results.forEach(menu => {
+      menus.push({
+        id: menu.itemId,
+        type: 'menu',
+        data: menu,
+      })
+    })
+
+    return { clips, boards, menus }
+  }, [clipItemsFiltered.results, boardsFiltered.results, menuItemsFiltered.results])
+
+  // Get current items array and total count
+  const getCurrentItems = () => {
+    if (filter === FILTER.CLIPS) return flattenedItems.clips
+    if (filter === FILTER.BOARDS) return flattenedItems.boards
+    if (filter === FILTER.MENUS) return flattenedItems.menus
+    return []
+  }
+
+  const getTotalItemsCount = () => {
+    return getCurrentItems().length
+  }
+
+  // Get available tabs with items
+  const getAvailableTabs = () => {
+    const tabs = []
+    if (flattenedItems.clips.length > 0) tabs.push(FILTER.CLIPS)
+    if (flattenedItems.boards.length > 0) tabs.push(FILTER.BOARDS)
+    if (flattenedItems.menus.length > 0) tabs.push(FILTER.MENUS)
+    return tabs
+  }
+
+  // Handle copying selected item
+  const handleCopySelectedItem = useCallback(async () => {
+    const currentItems = getCurrentItems()
+    if (
+      currentItems.length === 0 ||
+      selectedIndex < 0 ||
+      selectedIndex >= currentItems.length
+    )
+      return
+
+    const selectedItem = currentItems[selectedIndex]
+
+    if (selectedItem.type === 'clip') {
+      handleCopyClipItem(selectedItem.id)
+      setTimeout(() => {
+        setShowSearchModal(false)
+      }, 1000)
+    } else if (selectedItem.type === 'board') {
+      // For boards, navigate to the board
+      const boardData = selectedItem.data
+      if (boardData && boardData.tabId) {
+        setCurrentTab(boardData.tabId)
+        closeGlobalSearchNavigateHistory()
+      }
+    } else if (selectedItem.type === 'menu') {
+      // For menus, copy the menu item value
+      const menuData = selectedItem.data
+      if (menuData?.value) {
+        handleCopyClipItem(selectedItem.id)
+        setTimeout(() => {
+          setShowSearchModal(false)
+        }, 1000)
+      }
+    }
+  }, [
+    selectedIndex,
+    getCurrentItems,
+    handleCopyClipItem,
+    setCurrentTab,
+    closeGlobalSearchNavigateHistory,
+  ])
+
   useEffect(() => {
     if (!showSearchModal) {
       recentSearchTerm.value = searchTerm
@@ -250,15 +377,118 @@ export function GlobalSearch({ isDark }: { isDark: boolean }) {
   useHotkeys(['meta+k', 'ctrl+k', 'alt+k'], toggleSearch, {}, [])
   useHotkeys('/', toggleSearch, {}, [])
 
+  // Global keyboard event listener for search modal
   useEffect(() => {
-    if (!hasSearch || clipItemsFiltered.count > 0) {
+    if (!showSearchModal) return
+
+    const handleGlobalKeyDown = (e: KeyboardEvent) => {
+      // Only handle if search modal is open
+      if (!showSearchModal) return
+
+      if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        e.stopPropagation()
+        const totalItems = getTotalItemsCount()
+        if (totalItems > 0) {
+          setSelectedIndex(prev => (prev === -1 ? 0 : (prev + 1) % totalItems))
+        }
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        e.stopPropagation()
+        const totalItems = getTotalItemsCount()
+        if (totalItems > 0) {
+          setSelectedIndex(prev =>
+            prev === -1 ? totalItems - 1 : (prev - 1 + totalItems) % totalItems
+          )
+        }
+      } else if (e.key === 'Tab' && !e.shiftKey) {
+        e.preventDefault()
+        e.stopPropagation()
+        const availableTabs = getAvailableTabs()
+        if (availableTabs.length > 1) {
+          const currentTabIndex = availableTabs.indexOf(filter)
+          const nextTabIndex = (currentTabIndex + 1) % availableTabs.length
+          setFilter(availableTabs[nextTabIndex])
+          setSelectedIndex(-1)
+        }
+      } else if (e.key === 'Tab' && e.shiftKey) {
+        e.preventDefault()
+        e.stopPropagation()
+        const availableTabs = getAvailableTabs()
+        if (availableTabs.length > 1) {
+          const currentTabIndex = availableTabs.indexOf(filter)
+          const prevTabIndex =
+            (currentTabIndex - 1 + availableTabs.length) % availableTabs.length
+          setFilter(availableTabs[prevTabIndex])
+          setSelectedIndex(-1)
+        }
+      } else if (e.key === 'Enter') {
+        e.preventDefault()
+        e.stopPropagation()
+        if (selectedIndex >= 0) {
+          handleCopySelectedItem()
+        }
+      } else if (e.key === 'Escape') {
+        e.preventDefault()
+        e.stopPropagation()
+        setShowSearchModal(false)
+      }
+    }
+
+    // Add listener with high priority (capture phase)
+    document.addEventListener('keydown', handleGlobalKeyDown, true)
+
+    return () => {
+      document.removeEventListener('keydown', handleGlobalKeyDown, true)
+    }
+  }, [
+    showSearchModal,
+    getTotalItemsCount,
+    getAvailableTabs,
+    filter,
+    handleCopySelectedItem,
+  ])
+
+  useEffect(() => {
+    if (!hasSearch || flattenedItems.clips.length > 0) {
       setFilter(FILTER.CLIPS)
-    } else if (boardsFiltered.count > 0) {
+    } else if (flattenedItems.boards.length > 0) {
       setFilter(FILTER.BOARDS)
-    } else if (menuItemsFiltered.count > 0) {
+    } else if (flattenedItems.menus.length > 0) {
       setFilter(FILTER.MENUS)
     }
-  }, [clipItemsFiltered.count, boardsFiltered.count, hasSearch])
+  }, [
+    flattenedItems.clips.length,
+    flattenedItems.boards.length,
+    flattenedItems.menus.length,
+    hasSearch,
+  ])
+
+  // Reset selected index when search term or filter changes
+  useEffect(() => {
+    setSelectedIndex(-1)
+  }, [debouncedSearchTerm, filter])
+
+  // Scroll to selected item when index changes
+  useEffect(() => {
+    if (scrollContainerRef.current && showSearchModal && selectedIndex >= 0) {
+      // Get the actual DOM element from SimpleBar component
+      // @ts-expect-error
+      const simpleBarElement = scrollContainerRef.current?.el
+      const container = simpleBarElement?.querySelector('.simplebar-content-wrapper')
+      const selectedElement = container?.querySelector(`.search-item-${selectedIndex}`)
+      if (selectedElement && container) {
+        const containerRect = container.getBoundingClientRect()
+        const elementRect = selectedElement.getBoundingClientRect()
+        const isAbove = elementRect.top < containerRect.top
+        const isBelow = elementRect.bottom > containerRect.bottom
+
+        if (isAbove || isBelow) {
+          selectedElement.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+        }
+      }
+    }
+  }, [selectedIndex, showSearchModal])
 
   useEffect(() => {
     if (showSearchModal && (copiedItem || pastedItem) && isAutoCloseOnCopyPaste) {
@@ -275,7 +505,9 @@ export function GlobalSearch({ isDark }: { isDark: boolean }) {
         modal={false}
         open={showSearchModal}
         onOpenChange={() => {
-          setShowSearchModal(!showSearchModal)
+          const newShow = !showSearchModal
+          setShowSearchModal(newShow)
+          resetKeyboardNavigation()
         }}
       >
         <PopoverAnchor asChild>
@@ -329,6 +561,10 @@ export function GlobalSearch({ isDark }: { isDark: boolean }) {
           sideOffset={4}
           onOpenAutoFocus={e => {
             e.preventDefault()
+            // Keep focus on the input when modal opens
+            setTimeout(() => {
+              searchHistoryInputRef.current?.focus()
+            }, 0)
           }}
           onInteractOutside={e => {
             e.preventDefault()
@@ -423,7 +659,9 @@ export function GlobalSearch({ isDark }: { isDark: boolean }) {
                       variant="outline"
                       className="text-[12px] ml-1 py-0.5 bg-slate-100 text-gray-400 dark:bg-slate-700 dark:text-gray-400 !font-mono border-0"
                     >
-                      {clipItemsFiltered.count > 99 ? '99+' : clipItemsFiltered.count}
+                      {flattenedItems.clips.length > 99
+                        ? '99+'
+                        : flattenedItems.clips.length}
                     </Badge>
                   </TabsTrigger>
                   <TabsTrigger
@@ -435,7 +673,9 @@ export function GlobalSearch({ isDark }: { isDark: boolean }) {
                       variant="outline"
                       className="text-[12px] ml-1 py-0.5 bg-slate-100 text-gray-400 dark:bg-slate-700 dark:text-gray-400 !font-mono border-0"
                     >
-                      {boardsFiltered.count > 99 ? '99+' : boardsFiltered.count}
+                      {flattenedItems.boards.length > 99
+                        ? '99+'
+                        : flattenedItems.boards.length}
                     </Badge>
                   </TabsTrigger>
                   <TabsTrigger
@@ -447,13 +687,16 @@ export function GlobalSearch({ isDark }: { isDark: boolean }) {
                       variant="outline"
                       className="text-[12px] ml-1 py-0.5 bg-slate-100 text-gray-400 dark:bg-slate-700 dark:text-gray-400 !font-mono border-0"
                     >
-                      {menuItemsFiltered.count > 99 ? '99+' : menuItemsFiltered.count}
+                      {flattenedItems.menus.length > 99
+                        ? '99+'
+                        : flattenedItems.menus.length}
                     </Badge>
                   </TabsTrigger>
                 </TabsList>
               </Tabs>
             )}
             <SimpleBar
+              ref={mergeRefs(scrollContainerRef)}
               className="flex-col"
               style={{
                 height: 'auto',
@@ -478,22 +721,53 @@ export function GlobalSearch({ isDark }: { isDark: boolean }) {
                   .map((boardGroup: Board[], groupIndex) => {
                     return (
                       <Box key={`${groupIndex}`} className="mt-1 mb-2">
-                        {boardGroup.map((board: Board, index) => (
-                          <BoardComponentMemorized
-                            key={`${groupIndex}-${index}`}
-                            board={board}
-                            isDark={isDark}
-                            closeGlobalSearch={closeGlobalSearchNavigateHistory}
-                            setCurrentTab={setCurrentTab}
-                            globalSearchTerm={debouncedSearchTerm}
-                            isHistoryDragActive={false}
-                            currentTabLayout={'auto'}
-                            order={board.orderNumber}
-                            isLastBoard={index === boardGroup.length - 1}
-                            selectedItemIds={[]}
-                            setSelectedItemId={() => {}}
-                          />
-                        ))}
+                        {boardGroup.map((board: Board, index) => {
+                          // Find if any clips in this board are selected
+                          const currentItems = getCurrentItems()
+                          const selectedClipId =
+                            selectedIndex >= 0
+                              ? currentItems
+                                  .filter(
+                                    item =>
+                                      item.type === 'clip' &&
+                                      item.boardIndex === groupIndex
+                                  )
+                                  .map(item => {
+                                    const globalIndex = currentItems.findIndex(
+                                      ci => ci.id === item.id
+                                    )
+                                    return globalIndex === selectedIndex ? item.id : null
+                                  })
+                                  .filter(Boolean)[0] || null
+                              : null
+
+                          return (
+                            <Box
+                              key={`${groupIndex}-${index}`}
+                              className={clsx(
+                                'rounded-md transition-colors',
+                                `search-item-${groupIndex}`
+                              )}
+                            >
+                              <BoardComponentMemorized
+                                board={board}
+                                isDark={isDark}
+                                closeGlobalSearch={closeGlobalSearchNavigateHistory}
+                                setCurrentTab={setCurrentTab}
+                                globalSearchTerm={debouncedSearchTerm}
+                                isHistoryDragActive={false}
+                                currentTabLayout={'auto'}
+                                order={board.orderNumber}
+                                isLastBoard={index === boardGroup.length - 1}
+                                selectedItemIds={[]}
+                                setSelectedItemId={() => {}}
+                                keyboardSelectedClipId={{
+                                  value: selectedClipId as UniqueIdentifier,
+                                }}
+                              />
+                            </Box>
+                          )
+                        })}
                       </Box>
                     )
                   })}
@@ -514,23 +788,41 @@ export function GlobalSearch({ isDark }: { isDark: boolean }) {
                   .map((boardGroup: Board[], groupIndex) => {
                     return (
                       <Box key={`${groupIndex}`} className="mt-1 mb-2">
-                        {boardGroup.map((board: Board, index) => (
-                          <BoardComponentMemorized
-                            key={`${groupIndex}-${index}`}
-                            board={board}
-                            isDark={isDark}
-                            globalSearchTerm={debouncedSearchTerm}
-                            setCurrentTab={setCurrentTab}
-                            closeGlobalSearch={closeGlobalSearchNavigateHistory}
-                            isHistoryDragActive={false}
-                            isGlobalSearchBoardsOnly={true}
-                            currentTabLayout={'auto'}
-                            order={board.orderNumber}
-                            isLastBoard={index === boardGroup.length - 1}
-                            selectedItemIds={[]}
-                            setSelectedItemId={() => {}}
-                          />
-                        ))}
+                        {boardGroup.map((board: Board, index) => {
+                          // Check if this board is the currently selected item
+                          const currentItems = getCurrentItems()
+                          const isSelected =
+                            selectedIndex >= 0 &&
+                            currentItems[selectedIndex]?.type === 'board' &&
+                            currentItems[selectedIndex]?.id === board.id
+                          return (
+                            <Box
+                              key={`${groupIndex}-${index}`}
+                              className={clsx(
+                                'rounded-md transition-colors',
+                                `search-item-${selectedIndex}`,
+                                isSelected &&
+                                  'bg-blue-100 dark:bg-blue-900/30 ring-2 outline-none scale-[.98] ring-blue-400 dark:!ring-blue-600 ring-offset-1 ring-offset-white dark:ring-offset-gray-800'
+                              )}
+                            >
+                              <BoardComponentMemorized
+                                board={board}
+                                isDark={isDark}
+                                globalSearchTerm={debouncedSearchTerm}
+                                setCurrentTab={setCurrentTab}
+                                closeGlobalSearch={closeGlobalSearchNavigateHistory}
+                                isHistoryDragActive={false}
+                                isGlobalSearchBoardsOnly={true}
+                                currentTabLayout={'auto'}
+                                order={board.orderNumber}
+                                isLastBoard={index === boardGroup.length - 1}
+                                selectedItemIds={[]}
+                                setSelectedItemId={() => {}}
+                                keyboardSelectedClipId={{ value: null }}
+                              />
+                            </Box>
+                          )
+                        })}
                       </Box>
                     )
                   })}
@@ -540,41 +832,58 @@ export function GlobalSearch({ isDark }: { isDark: boolean }) {
                   collapsible
                   className="flex items-center flex-col"
                 >
-                  {menuItemsFiltered.results.map((item, i) => (
-                    <AccordionItem key={`${item.itemId}`} value={item.itemId}>
-                      <MenuCollapsibleItem
-                        label={item.name}
-                        globalSearchTerm={debouncedSearchTerm}
-                        closeGlobalSearch={closeGlobalSearchNavigateMenu}
-                        isLastItem={i === menuItemsFiltered.results.length - 1}
-                        deletingMenuItemIds={deletingMenuItemIds}
-                        isFirstItem={i === 0}
-                        isDark={isDark}
-                        showEditMenuItemId={showEditMenuItemId}
-                        hasChildren={item.hasChildren}
-                        isSeparator={item.isSeparator}
-                        showMultiSelectItems={showMultiSelectItems}
-                        hasSelectedItems={false}
-                        id={item.itemId}
-                        item={item}
-                        isClip={item.isClip}
-                        isForm={item.isForm && item.isClip}
-                        isWebRequest={item.isWebRequest && item.isClip}
-                        isWebScraping={item.isWebScraping && item.isClip}
-                        isCommand={item.isCommand && item.isClip}
-                        isCreatingMenuItem={isCreatingMenuItem}
-                        indent={item.indent}
-                        onFolderClose={() => {}}
-                        onFolderOpen={() => {}}
-                        isClosedFolder={false}
-                        isSelected={false}
-                        hasMultipleSelectedItems={false}
-                        isOpen={false}
-                      >
-                        <></>
-                      </MenuCollapsibleItem>
-                    </AccordionItem>
-                  ))}
+                  {menuItemsFiltered.results.map((item, i) => {
+                    // Check if this menu item is the currently selected item
+                    const currentItems = getCurrentItems()
+                    const isSelected =
+                      selectedIndex >= 0 &&
+                      currentItems[selectedIndex]?.type === 'menu' &&
+                      currentItems[selectedIndex]?.id === item.itemId
+                    return (
+                      <AccordionItem key={`${item.itemId}`} value={item.itemId}>
+                        <Box
+                          className={clsx(
+                            'rounded-md transition-colors',
+                            `search-item-${selectedIndex}`,
+                            isSelected &&
+                              'bg-blue-100 dark:bg-blue-900/30 ring-2 outline-none scale-[.98] ring-blue-400 dark:!ring-blue-600 ring-offset-1 ring-offset-white dark:ring-offset-gray-800'
+                          )}
+                        >
+                          <MenuCollapsibleItem
+                            label={item.name}
+                            globalSearchTerm={debouncedSearchTerm}
+                            closeGlobalSearch={closeGlobalSearchNavigateMenu}
+                            isLastItem={i === menuItemsFiltered.results.length - 1}
+                            deletingMenuItemIds={deletingMenuItemIds}
+                            isFirstItem={i === 0}
+                            isDark={isDark}
+                            showEditMenuItemId={showEditMenuItemId}
+                            hasChildren={item.hasChildren}
+                            isSeparator={item.isSeparator}
+                            showMultiSelectItems={showMultiSelectItems}
+                            hasSelectedItems={false}
+                            id={item.itemId}
+                            item={item}
+                            isClip={item.isClip}
+                            isForm={item.isForm && item.isClip}
+                            isWebRequest={item.isWebRequest && item.isClip}
+                            isWebScraping={item.isWebScraping && item.isClip}
+                            isCommand={item.isCommand && item.isClip}
+                            isCreatingMenuItem={isCreatingMenuItem}
+                            indent={item.indent}
+                            onFolderClose={() => {}}
+                            onFolderOpen={() => {}}
+                            isClosedFolder={false}
+                            isSelected={false}
+                            hasMultipleSelectedItems={false}
+                            isOpen={false}
+                          >
+                            <></>
+                          </MenuCollapsibleItem>
+                        </Box>
+                      </AccordionItem>
+                    )
+                  })}
                 </Accordion>
               )}
               {!hasSearch ? (
@@ -583,9 +892,9 @@ export function GlobalSearch({ isDark }: { isDark: boolean }) {
                 </Box>
               ) : (
                 <>
-                  {clipItemsFiltered.count === 0 &&
-                  boardsFiltered.count === 0 &&
-                  menuItemsFiltered.count === 0 ? (
+                  {flattenedItems.clips.length === 0 &&
+                  flattenedItems.boards.length === 0 &&
+                  flattenedItems.menus.length === 0 ? (
                     <Box className="text-gray-400/90 dark:text-gray-600 text-center mb-1">
                       {t('GlobalSearch:::Nothing found in clips, boards or menus.', {
                         ns: 'navbar',
@@ -593,7 +902,7 @@ export function GlobalSearch({ isDark }: { isDark: boolean }) {
                     </Box>
                   ) : (
                     <>
-                      {clipItemsFiltered.count === 0 && filter === FILTER.CLIPS && (
+                      {flattenedItems.clips.length === 0 && filter === FILTER.CLIPS && (
                         <Box className="text-gray-400/90 dark:text-gray-600 text-center mb-1">
                           {t('GlobalSearch:::Nothing found in clips.', {
                             ns: 'navbar',
@@ -601,7 +910,7 @@ export function GlobalSearch({ isDark }: { isDark: boolean }) {
                         </Box>
                       )}
 
-                      {boardsFiltered.count === 0 && filter === FILTER.BOARDS && (
+                      {flattenedItems.boards.length === 0 && filter === FILTER.BOARDS && (
                         <Box className="text-gray-400/90 dark:text-gray-600 text-center mb-1">
                           {t('GlobalSearch:::Nothing found in boards.', {
                             ns: 'navbar',
@@ -609,7 +918,7 @@ export function GlobalSearch({ isDark }: { isDark: boolean }) {
                         </Box>
                       )}
 
-                      {menuItemsFiltered.count === 0 && filter === FILTER.MENUS && (
+                      {flattenedItems.menus.length === 0 && filter === FILTER.MENUS && (
                         <Box className="text-gray-400/90 dark:text-gray-600 text-center mb-1">
                           {t('GlobalSearch:::Nothing found in menus.', {
                             ns: 'navbar',


### PR DESCRIPTION
Support for notes matching in global search and keyboard navigation enhancements  

**Global Search Navigation:**
  - _Cmd/Ctrl + K, Alt + K, or / key:_ Opens the global search modal
  - _Search Input Focus:_ When the search input is focused, all history
  and board keyboard navigation is automatically disabled to prevent
  conflicts
  - _Arrow Down:_ Selects the first item in search results (if no item is
  selected), or navigates to the next item
  - _Arrow Up:_ Selects the last item in search results (if no item is
  selected), or navigates to the previous item
  - _Tab:_ Switches to the next available search category (Clips → Boards
  → Menus) with circular navigation
  - _Shift + Tab:_ Switches to the previous available search category
  (Menus → Boards → Clips) with circular navigation
  - _Enter:_ Copies the selected search result item and closes the search
  modal after a brief delay
  - _Esc:_ Closes the search modal and returns focus to the previous
  context
  - _No Initial Selection:_ Search results start with no item selected,
  requiring user to press Arrow Down/Up to begin navigation
