### PR TITLE
feat: Traditional Chinese (zh-TW) + CJK font fallback + global-hotkey unregister fix

### DIFF
--- a/packages/pastebar-app-ui/src/App.tsx
+++ b/packages/pastebar-app-ui/src/App.tsx
@@ -92,7 +92,7 @@ function App() {
   }, [isAppLocked.value])
 
   useEffect(() => {
-    appReady().then(res => {
+    appReady().then(async res => {
       if (res === null) return
 
       try {
@@ -282,6 +282,12 @@ function App() {
           settings.isScreenLockPassCodeRequireOnStart?.valueBool
         ) {
           isAppLocked.value = true
+        }
+
+        // Clear any previously-registered global shortcuts before (re)registering,
+        // so changing a hotkey does not leave the old one grabbed until app restart.
+        if (window.isMainWindow) {
+          await unregisterAll().catch(() => {})
         }
 
         if (settings.hotKeysShowHideMainAppWindow?.valueText) {

--- a/packages/pastebar-app-ui/src/locales/date-locales/index.ts
+++ b/packages/pastebar-app-ui/src/locales/date-locales/index.ts
@@ -5,12 +5,13 @@ import it from 'date-fns/locale/it'
 import ru from 'date-fns/locale/ru'
 import uk from 'date-fns/locale/uk'
 import zhCN from 'date-fns/locale/zh-CN'
+import zhTW from 'date-fns/locale/zh-TW'
 
 interface LocaleMap {
   [key: string]: Locale
 }
 
-const locales: LocaleMap = { en, esES, ru, uk, it, zhCN }
+const locales: LocaleMap = { en, esES, ru, uk, it, zhCN, zhTW }
 
 export function formatLocale(date: Date | number, formatStr = 'Pp'): string {
   const currentLocale = window.__locale__ || 'en'

--- a/packages/pastebar-app-ui/src/locales/lang/zhTW/backuprestore.yaml
+++ b/packages/pastebar-app-ui/src/locales/lang/zhTW/backuprestore.yaml
@@ -1,0 +1,46 @@
+Auto Backup on Restore: 還原時自動備份
+Available Backups: 可用備份
+Backup Files: 備份檔案
+Backup Now: 立即備份
+Backup and Restore: 備份與還原
+Backup created successfully: 備份建立成功
+Backup deleted successfully: 備份刪除成功
+Backup on Restore: 還原時備份
+Browse: 瀏覽
+Create Backup: 建立備份
+Create a backup of your data?: 要建立您的資料備份嗎？
+Created: 建立時間
+Creating backup...: 正在建立備份...
+Delete: 刪除
+Delete this backup? This action cannot be undone.: 刪除此備份？此操作無法復原。
+Failed to create backup: 備份建立失敗
+Failed to delete backup: 備份刪除失敗
+Failed to load backup list: 備份清單載入失敗
+Failed to open backup folder: 備份資料夾開啟失敗
+Failed to restore backup: 備份還原失敗
+Failed to select backup file: 備份檔案選取失敗
+Include images in backup: 在備份中包含圖片
+Invalid backup file: 無效的備份檔案
+Loading backups...: 正在載入備份...
+Move to another location?: 移動到其他位置？
+No backups found: 未找到備份
+Restore: 還原
+Restore Data: 還原資料
+Restore completed. The application will restart.: 還原完成。應用程式將重新啟動。
+Restore from "{{filename}}"? This will replace all current data.: 從「{{filename}}」還原？這將取代所有目前的資料。
+Restore from File...: 從檔案還原...
+Restore from {{filename}}? This will replace all current data.: 從 {{filename}} 還原？這將取代所有目前的資料。
+Restored from {{filename}}: 已從 {{filename}} 還原
+Restoring a backup will automatically restart the application.: 還原備份將自動重新啟動應用程式。
+Restoring backup...: 正在還原備份...
+Restoring...: 還原中...
+Select backup file: 選擇備份檔案
+Size: 大小
+The selected file is not a valid PasteBar backup: 所選檔案不是有效的 PasteBar 備份
+This action cannot be undone. All current data will be replaced with the backup data.: 此操作無法復原。所有目前的資料將被備份資料取代。
+This will create a backup file containing your database: 這將建立一個包含您資料庫的備份檔案
+This will replace all current data. Are you sure?: 這將取代所有目前的資料。您確定嗎？
+Total backup space {{size}}: '備份總空間：{{size}}'
+and images: 和圖片
+selected file: 所選檔案
+will be permanently deleted.: 將被永久刪除。

--- a/packages/pastebar-app-ui/src/locales/lang/zhTW/calendar.yaml
+++ b/packages/pastebar-app-ui/src/locales/lang/zhTW/calendar.yaml
@@ -1,0 +1,22 @@
+Day: 天
+Days: 天
+Days2: 天
+Days3: 天
+Month: 月
+Months: 月
+Months2: 月
+Older then: 早於
+Hour: 小時
+Hours: 小時
+Week: 週
+Weeks: 週
+Week2: 週
+Year: 年
+Years: 年
+Years2: 年
+and older: 及更早
+last: 最近
+last2: 最近
+last3: 最近
+older then: 早於
+recent: 最近

--- a/packages/pastebar-app-ui/src/locales/lang/zhTW/collections.yaml
+++ b/packages/pastebar-app-ui/src/locales/lang/zhTW/collections.yaml
@@ -1,0 +1,26 @@
+Add Collection: 新增收藏集
+Add a description for your collection: 為您的收藏集新增描述
+Add default menu, tab and board: 新增預設選單、分頁與看板
+Are you sure you want to delete this collection?: 確定要刪除此收藏集嗎？
+Choose which collections require PIN entry for access.: 選擇哪些收藏集需要輸入 PIN 才能存取。
+Collection Options: 收藏集選項
+Collection Title: 收藏集標題
+Collections: 收藏集
+Current Collection: 目前收藏集
+Delete Collection: 刪除收藏集
+Delete all menu items within this collection: 刪除此收藏集中的所有選單項目
+? Deleting the collection will remove it permanently. You can also choose to delete all menu and clips items within the collection by checking the box below.
+: 刪除此收藏集將永久移除。您也可以勾選下方核取方塊，同時刪除收藏集內的所有選單與片段項目。
+Description: 描述
+Display full name of selected collection on the navigation bar: 在導覽列顯示所選收藏集的完整名稱
+Enter collection title: 輸入收藏集標題
+Manage Collections: 管理收藏集
+Pin Protected Collections: PIN 保護的收藏集
+Protect Collections with PIN: 以 PIN 保護收藏集
+Protected Collection: 受保護的收藏集
+Select Collections: 選擇收藏集
+Select protected collections: 選擇受保護的收藏集
+Show collection name on the navbar: 在導覽列顯示收藏集名稱
+Switch collections: 切換收藏集
+You can add the selected text to your clips or menu. Please select the option below.: 您可以將所選文字新增至片段或選單。請在下方選擇選項。
+You need to select a different collection before deleting the current one.: 刪除目前收藏集前，請先選擇另一個收藏集。

--- a/packages/pastebar-app-ui/src/locales/lang/zhTW/common.yaml
+++ b/packages/pastebar-app-ui/src/locales/lang/zhTW/common.yaml
@@ -1,0 +1,359 @@
+' No': ' 否'
+' This permission ensures PasteBar can access the clipboard and perform copy and paste operations across applications.': ' 此權限確保 PasteBar 可以存取剪貼簿，並在應用程式之間執行複製與貼上操作。'
+About PasteBar: 關於 PasteBar
+Action Menu: 操作選單
+? Add <b>{{Clipboard}}</b> field to template. This allows you to copy text to the clipboard, and it will be inserted into the template
+: 新增 <b>{{Clipboard}}</b> 欄位至範本。這可讓您將文字複製到剪貼簿，並自動插入範本中。
+Add Clip: 新增片段
+Add First Option: 新增第一個選項
+Add Link Card: 新增連結卡片
+Add Menu: 新增選單
+Add Option: 新增選項
+Add PasteBar to Accessibility: 將 PasteBar 加入輔助使用
+Add To Player: 加入播放器
+Add to: 加入
+Add to Clips: 加入片段
+Add to Clips or Menu: 加入片段或選單
+Add to Menu: 加入選單
+Add to clip or menu: 加入片段或選單
+Add to template fields: 加入範本欄位
+Added: 已新增
+Adding this file to the player is not recommended unless you trust the source.: 除非您信任來源，否則不建議將此檔案加入播放器。
+Allow PasteBar to Copy and Paste from Clipboard: 允許 PasteBar 從剪貼簿複製與貼上
+Are you sure you want to delete?: 確定要刪除嗎？
+Are you sure?: 確定嗎？
+Attach History Window: 附加歷史視窗
+Back: 返回
+Build on {{buildDate}}: 建置於 {{buildDate}}
+Cancel: 取消
+Cancel Reset: 取消重設
+Check: 檢查
+Check / Done: 檢查 / 完成
+Check and Close: 檢查並關閉
+Check and Done: 檢查並完成
+Clear History: 清除歷史
+Clear Tracks: 清除曲目
+Clear found results and filters: 清除搜尋結果與篩選條件
+Click to Confirm: 點擊確認
+Clip: 片段
+Clip Boards: 看板
+Clipboard: 剪貼簿
+Clipboard History: 剪貼簿歷史
+Clipboard History Only: 僅剪貼簿歷史
+Clipboard History Settings: 剪貼簿歷史設定
+Close: 關閉
+Close Edit: 關閉編輯
+Close Expand Edit: 關閉展開編輯
+Close Find: 關閉搜尋
+Close History Window: 關閉歷史視窗
+Close modal and continue in browser: 關閉對話框並在瀏覽器中繼續
+Confirm: 確認
+Confirm  action: 確認操作
+Confirm Delete: 確認刪除
+Confirm Email: 確認電子郵件
+Confirm Passcode: 確認密碼
+Confirm Password: 確認密碼
+Confirm Remove: 確認移除
+Confirm Your Passcode: 確認您的密碼
+Confirm Passcode Reset: 確認密碼重設
+Confirm Password Reset: 確認密碼重設
+Confirm Add To Protected Collections: 確認加入受保護的收藏集
+Confirm Disable PIN Protection: 確認停用 PIN 保護
+Confirm Remove From Protected Collections: 確認從受保護的收藏集中移除
+Confirm Enable PIN Protection: 確認啟用 PIN 保護
+Contact Form: 聯絡表單
+Copied: 已複製
+Copy: 複製
+Copy & Paste: 複製貼上
+Copy and Paste: 複製貼上
+'Copy of ': '複製 '
+Copy to Clipboard: 複製到剪貼簿
+Create: 建立
+Created: 已建立
+Delay Next: 延遲下一個
+Delete: 刪除
+Deselect All: 取消全選
+Deselect pinned: 取消選取已釘選
+Digits Only Passcode: 純數字密碼
+Disabled: 已停用
+Done: 完成
+Done Adding: 新增完成
+Done Edit: 編輯完成
+Done Reorder: 重新排序完成
+Download mp3: 下載 mp3
+Drag: 拖曳
+Drag to Move: 拖曳以移動
+Drop To Add: 拖放以新增
+Drop Zone: 拖放區
+Edit: 編輯
+Edit Label: 編輯標籤
+'Email: {{email}}': '電子郵件：{{email}}'
+Emoji: 表情符號
+Empty: 空
+Empty Select: 空選取
+Enable / Disable: 啟用 / 停用
+Enable PasteBar in Accessibility Settings: 在輔助使用設定中啟用 PasteBar
+Enabled: 已啟用
+Enter Current Passcode: 輸入目前密碼
+Enter Digits Only Passcode: 輸入純數字密碼
+Enter Email: 輸入電子郵件
+Enter PIN to Access Protected Collection: 輸入 PIN 以存取受保護的收藏集
+Enter Passcode: 輸入密碼
+Enter Password: 輸入密碼
+Enter Recovery Password: 輸入復原密碼
+Enter passcode or password to unlock: 輸入密碼以解鎖
+Error: 錯誤
+Errors:
+  Error loading link: 載入連結錯誤
+  Cant save to file: 無法儲存至檔案
+  Something went wrong! {{err}} Please try again.: 發生錯誤！{{err}} 請重試。
+Expand Edit: 展開編輯
+Expires on {{proExpiresOn}}: 於 {{proExpiresOn}} 到期
+? Field <b>{{Clipboard}}</b> has been found in the template. This allows you to copy text to the clipboard, and it will be inserted into the template
+: 已在範本中找到 <b>{{Clipboard}}</b> 欄位。這可讓您將文字複製到剪貼簿，並自動插入範本中。
+Field is not found in the template: 在範本中找不到此欄位
+Find Clip: 搜尋片段
+Find History: 搜尋歷史
+Found in template but missing from fields definition: 已在範本中找到，但欄位定義中缺少
+Got it: 瞭解
+Hide Muli Select: 隱藏多重選取
+Hide Pinned Board: 隱藏已釘選看板
+History: 歷史
+Image: 圖片
+Image Scale {{ImageScale}}x: 圖片縮放 {{ImageScale}}x
+Image size: 圖片大小
+Image size in pixels: 圖片大小（像素）
+In View: 檢視中
+In View Edit: 檢視中編輯
+Inactive: 非使用中
+Large View: 大型檢視
+Large View Edit: 大型檢視編輯
+Later: 稍後
+Light: 淺色
+Lines Wrap: 自動換行
+Make Active: 設為使用中
+Make Disabled: 設為停用
+Make Enabled: 設為啟用
+Make Inactive: 設為非使用中
+Manage: 管理
+Maximum height: 最大高度
+Maximum length: 最大長度
+Maximum width: 最大寬度
+Menu: 選單
+Minimum length: 最小長度
+Move Down: 向下移動
+Move Up: 向上移動
+Multi Select: 多重選取
+'Name: {{name}}': '名稱：{{name}}'
+Next Delay: 下一個延遲
+Next Track: 下一曲目
+No: 否
+No Key Press: 無按鍵
+No Wrap: 不換行
+Not Now: 暫不
+Not found in the template: 在範本中找不到
+Nothing found: 未找到任何內容
+Number of lines: 行數
+Ok, but later: 好的，稍後
+Open: 開啟
+Open Accessibility: 開啟輔助使用
+Open History Window: 開啟歷史視窗
+Open Window: 開啟視窗
+Open contact form in browser: 在瀏覽器中開啟聯絡表單
+Open payment in browser: 在瀏覽器中開啟付款
+Options: 選項
+Password: 密碼
+Paste Delay: 貼上延遲
+Paste Menu: 貼上選單
+Paste in {{pastingCountDown}}...: 將在 {{pastingCountDown}} 後貼上...
+PasteBar: PasteBar
+PasteBar Application Error: PasteBar 應用程式錯誤
+PasteBar History: PasteBar 歷史
+PasteBar application now can access the clipboard and perform copy and paste operations across applications.: PasteBar 應用程式現在可以存取剪貼簿，並在應用程式之間執行複製與貼上操作。
+PasteBar was successfuly added to Accessibility settings: PasteBar 已成功加入輔助使用設定
+Pasted: 已貼上
+Path: 路徑
+Pause: 暫停
+Pause Playing: 暫停播放
+? 'Permission Check Failed: PasteBar has not been successfully added to Accessibility settings. Please grant the required permissions and click Done again.'
+: '權限檢查失敗：PasteBar 尚未成功加入輔助使用設定。請授予所需權限，然後再次點擊完成。'
+Pin Selected: 釘選已選取
+Pinned: 已釘選
+Play: 播放
+Please add PasteBar to the list of apps in: 請將 PasteBar 加入以下應用程式清單：
+Please confirm your action!: 請確認您的操作！
+Press: 按下
+Press ESC key to close: 按 ESC 鍵關閉
+Previous Track: 上一曲目
+Pro: 專業版
+Quit: 結束
+Rebuild Menu: 重建選單
+Recent History: 最近歷史
+Recovery Password: 復原密碼
+Remove: 移除
+Remove Link Card: 移除連結卡片
+Remove Selected Star: 移除已選取的星號
+Remove all fields from template: 從範本中移除所有欄位
+Remove all tracks: 移除所有曲目
+Remove current track: 移除目前曲目
+Remove from Player: 從播放器移除
+Remove from template: 從範本移除
+Rename: 重新命名
+Renew: 續約
+Reorder pinned: 重新排序已釘選項目
+Repeat 1: 單曲循環
+Repeat all: 全部循環
+Repeat off: 關閉循環
+Report and Try Again: 回報並重試
+Reset: 重設
+Reset Passcode: 重設密碼
+Reset Password: 重設密碼
+Reset with Passcode: 使用密碼重設
+Restart: 重新啟動
+Reverse Order: 反向排序
+Run and Copy Response: 執行並複製回應
+Run and Paste Response: 執行並貼上回應
+Running: 執行中
+Save: 儲存
+Save It!: 儲存！
+Saved: 已儲存
+Scroll to Top: 捲動至頂端
+Second: 秒
+Seconds: 秒
+'Security Alert: MP3 Verification Failed': '安全警告：MP3 驗證失敗'
+Select: 選取
+Select Default Option: 選取預設選項
+Select Language: 選擇語言
+Select default: 選取預設
+Select is empty: 選取為空
+Select option: 選取選項
+Select pinned: 選取已釘選項目
+Separate History Window: 獨立歷史視窗
+Sequence Copy: 依序複製
+Sequence Copy Paste: 依序複製貼上
+Sequence Delay Next: 依序延遲下一個
+Sequence Next Delay: 依序下一個延遲
+Sequence Paste: 依序貼上
+Sequence Reverse Order: 依序反向排序
+Set: 設定
+Set Password: 設定密碼
+Show Large View: 顯示大型檢視
+Show all: 顯示全部
+Size: 大小
+Source: 來源
+Star: 星號
+Star Selected: 為已選取加上星號
+Stay here: 留在此處
+Stay in touch: 保持聯繫
+Success!: 成功！
+Swap Panels Layout: 交換面板配置
+System Settings -> Privacy & Security -> Accessibility: 系統設定 -> 隱私權與安全性 -> 輔助使用
+Thank you for reporting the error.: 感謝您回報錯誤。
+Thank you for using Pro: 感謝您使用專業版
+Thank you!: 謝謝！
+This permission ensures PasteBar can access the clipboard and perform copy and paste operations across applications.: 此權限確保 PasteBar 可以存取剪貼簿，並在應用程式之間執行複製與貼上操作。
+Too long: 太長
+Too short: 太短
+Toolbar:
+  Blank Text Formatting: 空白文字格式
+  Bold Formatting: 粗體格式
+  Bold Text Formatting: 粗體文字格式
+  Copy and Paste Formatting: 複製貼上格式
+  Header Formatting: 標題格式
+  Hightlight Text Formatting: 螢光標示文字格式
+  Italic Formatting: 斜體格式
+  Masked Text Formatting: 遮罩文字格式
+  Remove Text Formatting: 移除文字格式
+Trust and Play: 信任並播放
+Type:
+  App: 應用程式
+  Auto Fill: 自動填入
+  AutoFill: 自動填入
+  Clip: 片段
+  Code: 程式碼
+  Code Snippet: 程式碼片段
+  Command: 指令
+  Email: 電子郵件
+  Emoji: 表情符號
+  Empty: 空
+  Error: 錯誤
+  File: 檔案
+  File, Path or App: 檔案、路徑或應用程式
+  Form Auto Fill: 表單自動填入
+  Image: 圖片
+  Label: 標籤
+  Link: 連結
+  Link or Email: 連結或電子郵件
+  Menu: 選單
+  Mp3: mp3
+  Path: 路徑
+  Plain Text: 純文字
+  Request: 請求
+  Run Auto Fill: 執行自動填入
+  Scraper: 擷取器
+  Secret: 密鑰
+  Trim: 修剪空白
+  Shell Command: Shell 指令
+  Submenu: 子選單
+  Template: 範本
+  Template Fill: 範本填入
+  Text: 文字
+  Video: 影片
+  Web Request (HTTP): 網路請求 (HTTP)
+  Web Scraper / Parser: 網路擷取器 / 解析器
+TypeMenu:
+  Clip Type: 片段類型
+  Code Snippet: 程式碼片段
+  File, Path or App: 檔案、路徑或應用程式
+  Form Auto Fill: 表單自動填入
+  Image: 圖片
+  Link or Email: 連結或電子郵件
+  Link or File, Path or App: 連結或檔案、路徑或應用程式
+  Plain Text: 純文字
+  Run, Execute: 執行
+  Select Language: 選擇語言
+  Shell Command: Shell 指令
+  Template: 範本
+  Template Fill: 範本填入
+  Text Template: 文字範本
+  Web Request (HTTP): 網路請求 (HTTP)
+  Web Scraper / Parser: 網路擷取器 / 解析器
+UnPin All: 取消釘選全部
+UnPin Selected: 取消釘選已選取
+Unlock Application Screen: 解鎖應用程式螢幕
+Unlock Pro features: 解鎖專業版功能
+Unlock Screen: 解鎖螢幕
+Unlock all features: 解鎖所有功能
+Unsaved label: 未儲存的標籤
+Update Error: 更新錯誤
+Update history list: 更新歷史清單
+Updated: 已更新
+Upgrade to Pro: 升級至專業版
+Use Passcode: 使用密碼
+Use Password: 使用密碼
+Using <b>{{Clipboard}}</b> field, allows you to copy text to the clipboard, and it will be inserted into the template: 使用 <b>{{Clipboard}}</b> 欄位，可讓您將文字複製到剪貼簿，並自動插入範本中
+Verify: 驗證
+Verify Current Password: 驗證目前密碼
+Verify Recovery Password: 驗證復原密碼
+Version: 版本
+View: 檢視
+View Edit: 檢視編輯
+Views:
+  Paste Menu: 貼上選單
+We apologize but you found a bug. Please report this issue to us and try again: 非常抱歉，您發現了一個錯誤。請向我們回報此問題，然後重試
+? We couldn't confirm this file's safety. Failed ID3 tag verification and integrity check. MP3 files can potentially contain malware. Please be cautious.
+: 我們無法確認此檔案的安全性。ID3 標籤驗證及完整性檢查失敗。MP3 檔案可能包含惡意軟體。請謹慎使用。
+Yes: 是
+Yes, activate: 是，啟用
+chars: 字元
+contact us.: 聯絡我們。
+found: 已找到
+if this error persists, try to restart the application or: 若此錯誤持續發生，請嘗試重新啟動應用程式或
+lines: 行
+menu items in: 選單項目在
+minutes: 分鐘
+only: 僅
+second: 秒
+seconds: 秒
+show less: 顯示較少
+www.site: www.pastebar.app

--- a/packages/pastebar-app-ui/src/locales/lang/zhTW/common2.yaml
+++ b/packages/pastebar-app-ui/src/locales/lang/zhTW/common2.yaml
@@ -1,0 +1,4 @@
+Please select your preferred language: 請選擇您偏好的語言
+Start using PasteBar: 開始使用 PasteBar
+Submenus will move up one level after delete: 刪除後子選單將自動上移一級
+Welcome to PasteBar: 歡迎使用 PasteBar

--- a/packages/pastebar-app-ui/src/locales/lang/zhTW/contextMenus.yaml
+++ b/packages/pastebar-app-ui/src/locales/lang/zhTW/contextMenus.yaml
@@ -1,0 +1,109 @@
+Activate: 啟用
+Add Board: 新增看板
+Add Clip: 新增片段
+Add First Tab: 新增第一個分頁
+Add Item: 新增項目
+Add Link Card: 新增連結卡片
+Add New: 新增
+Add New After: 在後方新增
+Add New Item: 新增項目
+Add Tab: 新增分頁
+Add to: 新增至
+Add to Menu: 新增至選單
+AddTo:
+  Add to Exclude and Delete: 新增至排除清單並刪除
+  Add to Filter by Source: 依來源新增至篩選器
+  Add to Ignore: 新增至忽略清單
+  Clip on Board: 看板上的片段
+  Paste Menu: 貼上選單
+After: 之後
+After Item: 項目之後
+Board Icon: 看板圖示
+Clip Icon: 片段圖示
+Close: 關閉
+Close Edit: 關閉編輯
+Close Rename: 關閉重新命名
+Close View: 關閉檢視
+Collapse View: 收合檢視
+Copy & Paste: 複製貼上
+Copy To: 複製到
+CopyTo:
+  Board: 看板
+  Tab: 分頁
+Custom Icon: 自訂圖示
+Dashboard: 儀表板
+Delete Board: 刪除看板
+Delete Clip: 刪除片段
+Deselect: 取消選取
+Detected Language: 偵測到的語言
+Down: 向下
+Duplicate: 複製
+Edit Board: 編輯看板
+Edit Clip: 編輯片段
+Edit Label: 編輯標籤
+Edit Tabs: 編輯分頁
+Edit Value: 編輯值
+End: 結尾
+Expand View: 展開檢視
+Hide: 隱藏
+Hide Details: 隱藏詳細資訊
+Hide Subtitle: 隱藏副標題
+Icon Type: 圖示類型
+Icon Visibility: 圖示顯示
+Large View: 大檢視
+Link To Clip: 連結至片段
+Locate Clip: 定位片段
+Locate Menu: 定位選單
+Make Disabled: 設為停用
+Make Enabled: 設為啟用
+Make Inactive: 設為非啟用
+Manage: 管理
+Mask Secret: 遮蔽密碼
+Menu: 選單
+Menu is Not Active: 選單未啟用
+Move Board To: 移動看板至
+Move To: 移動至
+MoveTo:
+  Board: 看板
+  Tab: 分頁
+Note Icon: 筆記圖示
+Note Icon Settings: 筆記圖示設定
+Note Icon Types Book: 書本
+Note Icon Types Contact: 聯絡人
+Note Icon Types File: 檔案
+Note Icon Types Message: 訊息
+Note Icon Types Notebook: 筆記本
+Open: 開啟
+Open Link in Browser: 在瀏覽器中開啟連結
+Organize: 整理
+Organize Layout: 整理版面
+Paste Delay: 貼上延遲
+Paste Menu: 貼上選單
+Pin: 釘選
+Position: 位置
+RESET: 重設
+Remove Link Card: 移除連結卡片
+Remove Star: 移除星號
+Rename: 重新命名
+Save as File: 另存為檔案
+Save as Image File: 另存為圖片檔案
+Save as Mp3: 另存為 Mp3
+Save as Mp3 File: 另存為 Mp3 檔案
+Save as Text File: 另存為文字檔案
+Select: 選取
+Select Icon: 選取圖示
+Separator: 分隔線
+Show: 顯示
+Show Large View: 顯示大檢視
+Show Note Icon: 顯示筆記圖示
+Show Subtitle: 顯示副標題
+Star: 加星號
+Start: 開頭
+Submenu: 子選單
+UnPin: 取消釘選
+UnPin Clip: 取消釘選片段
+Unmask Secret: 取消遮蔽密碼
+Up: 向上
+Use Global Setting: 使用全域設定
+View: 檢視
+not a code: 非程式碼

--- a/packages/pastebar-app-ui/src/locales/lang/zhTW/dashboard.yaml
+++ b/packages/pastebar-app-ui/src/locales/lang/zhTW/dashboard.yaml
@@ -1,0 +1,269 @@
+API Key: API 金鑰
+Add: 新增
+Add Auth: 新增驗證
+Add Clipboard Value: 新增剪貼簿值
+Add Custom: 新增自訂
+Add Custom Field: 新增自訂欄位
+Add Delay Time: 新增延遲時間
+Add First Board: 新增第一個看板
+Add Form Field: 新增表單欄位
+Add Header: 新增標頭
+Add Key Press: 新增按鍵
+Add Key Press After Paste: 貼上後新增按鍵
+Add Link Card: 新增連結卡片
+Add Open URL: 新增開啟網址
+Add Output Template: 新增輸出範本
+Add Regex Match Group Filter: 新增正規表示式群組篩選器
+Add Request Header: 新增請求標頭
+Add Response Filter: 新增回應篩選器
+Add Scraping Rule: 新增擷取規則
+Add Section: 新增區段
+Add Tab: 新增分頁
+Add Template Field: 新增範本欄位
+Add a Tab: 新增一個分頁
+Add field {{name}} into the template: 將欄位 {{name}} 新增至範本中
+Add image: 新增圖片
+Add note: 新增筆記
+Add to Board: 新增至看板
+Add {{type}}: 新增 {{type}}
+All field labels must be unique to ensure they are correctly used within the template.: 所有欄位標籤必須唯一，以確保在範本中正確使用。
+Are you sure you want to delete <strong>{{boardName}}</strong> board?: 確定要刪除 <strong>{{boardName}}</strong> 看板嗎？
+Are you sure you want to delete <strong>{{tabName}}</strong> tab?: 確定要刪除 <strong>{{tabName}}</strong> 分頁嗎？
+Are you sure you want to delete?: 確定要刪除嗎？
+Are you sure you want to remove image from the clip?: 確定要從片段中移除圖片嗎？
+Auth: 驗證
+Auto update is Off: 自動更新已關閉
+Basic Auth: 基本驗證
+Basic Password: 基本密碼
+Basic Username: 基本使用者名稱
+Bearer Token: Bearer Token
+Board Layout Height: 看板版面高度
+Board Layout Split: 看板版面分割
+Board Menu: 看板選單
+Board is Not Empty: 看板不為空
+Boards: 看板
+Border Width: 邊框寬度
+CSS Selector: CSS 選擇器
+Cancel: 取消
+Change Layout: 變更版面
+Change color: 變更顏色
+Clear: 清除
+Clear All Fields: 清除所有欄位
+Click To Add: 點擊新增
+Clip Menu: 片段選單
+Clip Options: 片段選項
+Clipboard: 剪貼簿
+Clips:
+  App: 應用程式
+  Clip Menu: 片段選單
+  Clips: 片段
+  Link: 連結
+Close Edit: 關閉編輯
+Command:
+  error: 錯誤
+  output: 輸出
+Command error: 指令錯誤
+Common Fields: 通用欄位
+Confirm Clear All Fields: 確認清除所有欄位
+Confirm to remove Auth: 確認移除驗證
+Confirm to remove filters: 確認移除篩選器
+Confirm to remove headers: 確認移除標頭
+Copy Clip: 複製片段
+Create Board: 建立看板
+Create Tab: 建立分頁
+Create tab: 建立分頁
+Dashboard: 儀表板
+Delay: 延遲
+Delete Board: 刪除看板
+Delete Clip: 刪除片段
+Delete Tab: 刪除分頁
+Delete board: 刪除看板
+Delete field: 刪除欄位
+Delete tab: 刪除分頁
+Detect Template Fields: 偵測範本欄位
+Detect for Template Fields: 偵測範本欄位
+Disabled field {{name}} has been found in the template: 在範本中發現已停用的欄位 {{name}}
+Done Create Clip: 片段建立完成
+Done Edit: 編輯完成
+Done Edit Tabs: 分頁編輯完成
+Done Organize: 整理完成
+Drag & Drop Path: 拖放路徑
+Drop To Add: 拖放以新增
+Drop image file here, or use a separate window for drag and drop.: 將圖片檔案拖放至此處，或使用獨立視窗進行拖放。
+Drop to Pin: 拖放以釘選
+Edit Note: 編輯筆記
+Edit Template: 編輯範本
+Edit subtitle: 編輯副標題
+Edit tab name: 編輯分頁名稱
+Enable / Disable: 啟用 / 停用
+Enable / Disable URL Open: 啟用 / 停用開啟 URL
+Enter Label: 輸入標籤
+Enter URL: 輸入 URL
+Enter board subtitle or description: 輸入看板副標題或說明
+Enter board title: 輸入看板標題
+Enter clip name: 輸入片段名稱
+Enter clip note: 輸入片段筆記
+Enter code: 輸入程式碼
+Enter credit card number: 輸入信用卡號碼
+Enter default value: 輸入預設值
+Enter field value: 輸入欄位值
+Enter full path to file, folder or application: 輸入檔案、資料夾或應用程式的完整路徑
+Enter regex for output filer: 輸入輸出篩選器的正規表示式
+Enter request url: 輸入請求 URL
+Enter secret value: 輸入密鑰值
+Enter section label: 輸入區段標籤
+Enter select option: 輸入選取選項
+Enter tab name: 輸入分頁名稱
+Enter template or drag from history: 輸入範本或從歷史拖入
+Enter template value: 輸入範本值
+Enter value or drag from history: 輸入值或從歷史拖入
+Enter web link or email: 輸入網頁連結或電子郵件
+Errors:
+  No fields found in the template.: 範本中未找到任何欄位。
+  Please fix output template or confirm to save as is.: 請修正輸出範本，或確認以現狀儲存。
+  Please fix template fields or confirm to save as is.: 請修正範本欄位，或確認以現狀儲存。
+  Please fix the problem or confirm to save as is.: 請修正問題，或確認以現狀儲存。
+  Please verify your link for any errors, or confirm to save as is.: 請確認連結是否有誤，或確認以現狀儲存。
+  Please verify your path for any errors, or confirm to save as is.: 請確認路徑是否有誤，或確認以現狀儲存。
+  Your command runs with errors, confirm you want to save as is.: 您的指令執行時發生錯誤，確認是否以現狀儲存。
+  Your request runs with errors, confirm you want to save as is.: 您的請求執行時發生錯誤，確認是否以現狀儲存。
+FILTERED_TYPES:
+  Dot Path: 點路徑
+  JSON Path: JSON 路徑
+  RegEx: 正規表示式
+  RegEx Replace: 正規表示式取代
+  Remove Quotes: 移除引號
+Field: 欄位
+Field Options: 欄位選項
+Field {{name}} has been found in the template: 在範本中發現欄位 {{name}}
+Fields Value: 欄位值
+File, folder or app path does not exist: 檔案、資料夾或應用程式路徑不存在
+File, folder or app path is valid: 檔案、資料夾或應用程式路徑有效
+File, folder or app path might not be valid: 檔案、資料夾或應用程式路徑可能無效
+Fill Template: 填寫範本
+Filter Type: 篩選類型
+Filter's Value: 篩選值
+Find in Clip: 在片段中搜尋
+Find in clip: 在片段中搜尋
+Find in history: 在歷史中搜尋
+Flex Layout: 彈性版面
+Form Fields: 表單欄位
+General Fields: 一般欄位
+Grid Layout: 格狀版面
+HTML: HTML
+Headers: 標頭
+Hide Label: 隱藏標籤
+History capture is off: 歷史擷取已關閉
+Key Press: 按鍵
+Key Press After: 之後按鍵
+Key Press After Paste: 貼上後按鍵
+'Key Press After Paste: {{keyPress}}': '貼上後按鍵：{{keyPress}}'
+Label Left: 標籤靠左
+Label Top: 標籤靠上
+Label on Left: 標籤在左側
+Labels: 標籤
+Last run: 上次執行
+Last update: 上次更新
+Layout Max Width: 版面最大寬度
+Mask to hide clipboard value in preview: 遮罩以在預覽時隱藏剪貼簿值
+Move Clip: 移動片段
+Moved Clips Panel: 已移動片段的面板
+Name: 名稱
+New Board: 新看板
+New Clip: 新片段
+No Boards: 沒有看板
+No Clipboard History: 沒有剪貼簿歷史
+No Tabs or Boards: 沒有分頁或看板
+Number of columns: 欄數
+Open: 開啟
+Open URL Disable / Enable: 開啟 URL 停用 / 啟用
+Output Template: 輸出範本
+Panel for moved or copied items from other tabs: 來自其他分頁已移動或複製項目的面板
+Please confirm to save as is.: 請確認以現狀儲存。
+Press: 按下
+RETURN_POSITION_TYPES:
+  First Only: 僅第一個
+  Last Only: 僅最後一個
+RULES_TYPES:
+  CSS Selector: CSS 選擇器
+  RegEx Find: 正規表示式尋找
+  RegEx Group Match: 正規表示式群組比對
+  RegEx Match: 正規表示式比對
+  RegEx Replace: 正規表示式取代
+RegEx Find: 正規表示式尋找
+RegEx Match: 正規表示式比對
+RegEx Match Group: 正規表示式比對群組
+RegEx Replace: 正規表示式取代
+Regex Match Group Filter: 正規表示式比對群組篩選器
+Remove Open URL: 移除開啟 URL
+Remove headers: 移除標頭
+Remove image: 移除圖片
+Rename: 重新命名
+Reset to Defaults: 重設為預設值
+Response Filters: 回應篩選器
+Result: 結果
+SEPARATOR_TYPES:
+  Comma (,): 逗號 (,)
+  New Line (\n): 換行 (\n)
+  Pipe (|): 垂直線 (|)
+  Semicolon (;): 分號 (;)
+  Space (' '): 空格 (' ')
+  Tab (\t): 定位字元 (\t)
+Save as Defaults: 儲存為預設值
+Scan for Template Fields: 掃描範本欄位
+Select Color: 選取顏色
+Select Default Option: 選取預設選項
+Select Option: 選取選項
+Select Options: 選取選項
+Show Label: 顯示標籤
+Special Field: 特殊欄位
+Subtitle: 副標題
+Tab: 分頁
+Tab is Not Empty: 分頁不為空
+Tabs Menu: 分頁選單
+Template: 範本
+Template Edit: 範本編輯
+Template Fields: 範本欄位
+'Template should have⠀<b>{{output}}</b>⠀placeholder.': 範本應包含⠀<b>{{output}}</b>⠀佔位符。
+Test Request: 測試請求
+Test Run: 測試執行
+Text: 文字
+This action cannot be undone.: 此操作無法復原。
+This field allows to insert text from clipboard: 此欄位允許從剪貼簿插入文字
+Too long: 太長
+Too short: 太短
+Turn On auto update: 開啟自動更新
+Turn on history capture: 開啟歷史擷取
+Type:
+  Command: 指令
+  Request: 請求
+  Scraper: 擷取器
+URL: URL
+Unsaved name: 未儲存的名稱
+Unsaved note: 未儲存的筆記
+Unsaved subtitle: 未儲存的副標題
+Unsaved title: 未儲存的標題
+Update Link Card: 更新連結卡片
+'Use double curly brackets for {{field name}}. Use {{clipboard}} to add current clipboard value.': 使用雙大括號表示 {{field name}}。使用 {{clipboard}} 新增目前的剪貼簿值。
+Value: 值
+Values: 值
+Vertical Split: 垂直分割
+We need to open a new window where you can drag & drop file, path or application.: 我們需要開啟一個新視窗，讓您可以在其中拖放檔案、路徑或應用程式。
+Web Link or Email might not be valid: 網頁連結或電子郵件可能無效
+Web or Email link is valid: 網頁或電子郵件連結有效
+Website URL: 網站 URL
+Website URL is valid: 網站 URL 有效
+Website URL might not be valid: 網站 URL 可能無效
+Wrap output using {{output}} placeholder: 使用 {{output}} 佔位符包裝輸出
+You have no rules added: 您尚未新增任何規則
+You'll need to clear this board of all clips and subboards before it can be deleted.: 刪除此看板前，您需要先清除其中所有片段與子看板。
+You'll need to clear this tab of all boards before it can be deleted.: 刪除此分頁前，您需要先清除其中所有看板。
+filled template: 已填寫的範本
+new clips: 新片段
+template: 範本
+'{{count}} fields found in template but missing from fields definition._one': '在範本中發現 {{count}} 個欄位，但欄位定義中缺少。'
+'{{count}} fields found in template but missing from fields definition._other': '在範本中發現 {{count}} 個欄位，但欄位定義中缺少。'
+'{{count}} fields not found in the template._one': '在範本中未找到 {{count}} 個欄位。'
+'{{count}} fields not found in the template._other': '在範本中未找到 {{count}} 個欄位。'
+'{{type}} Field': '{{type}} 欄位'
+'{{type}} field': '{{type}} 欄位'

--- a/packages/pastebar-app-ui/src/locales/lang/zhTW/help.yaml
+++ b/packages/pastebar-app-ui/src/locales/lang/zhTW/help.yaml
@@ -1,0 +1,88 @@
+Add Menu Item: 新增選單項目
+App Guided Tours: 應用程式導覽教學
+Board Panel: 看板面板
+Board Panel Header: 看板面板標題
+Boards and Clips: 看板與片段
+Boards and Clips Tour: 看板與片段導覽
+Clipboard History: 剪貼簿歷史
+Clipboard History Item: 剪貼簿歷史項目
+Clipboard History Panel: 剪貼簿歷史面板
+Clipboard History Settings: 剪貼簿歷史設定
+Clipboard History Tour: 剪貼簿歷史導覽
+Close Main Window: 關閉主視窗
+Collections Menu: 收藏集選單
+Congratulations! You have finished <strong>all the tours</strong> and now ready to make the most of PasteBar's features. Remember, all tours always available from the <strong>Help > App Guided Tours</strong> menu in the navbar.: 恭喜！您已完成<strong>所有導覽</strong>，現在可以充分運用 PasteBar 的各項功能了。請記住，所有導覽隨時可從導覽列的<strong>說明 > 應用程式導覽教學</strong>選單中取得。
+Contact Us Form: 聯絡我們表單
+Create Dashboard Items: 建立儀表板項目
+Dashboard Panel: 儀表板面板
+Dashboard Tabs: 儀表板分頁
+Done: 完成
+Feature Highlights: 功能亮點
+Feel free to explore the app on your own. If you need help or want to access the tours later, you can always find them in the <strong>Help > App Guided Tours</strong> menu in the navigation bar.: 歡迎自行探索應用程式。若您需要協助或想稍後再次查看導覽，隨時可在導覽列的<strong>說明 > 應用程式導覽教學</strong>選單中找到它們。
+Find Menu Items: 尋找選單項目
+Find and Filter History: 搜尋與篩選歷史
+Global Search: 全域搜尋
+Got It: 了解了
+Great job! You have completed this tour. Ready to see more? Click <i>Skip</i> if you want to explore on your own. All tours always available from the <strong>Help > App Guided Tours</strong> menu in the navbar.: 做得好！您已完成本次導覽。準備好繼續了嗎？若想自行探索，請點擊<i>略過</i>。所有導覽隨時可從導覽列的<strong>說明 > 應用程式導覽教學</strong>選單中取得。
+Guided Tours Options: 導覽教學選項
+Help: 說明
+Help Menu: 說明選單
+History Selected Items Menu: 歷史已選取項目選單
+History/Menu Navigation Tabs: 歷史／選單導覽分頁
+Later: 稍後
+Let's get started: 開始吧
+Manage Collections Settings: 管理收藏集設定
+Manage Paste Menu Panel: 管理貼上選單面板
+Mark All Completed: 全部標記為已完成
+Menu Item: 選單項目
+Menu Item Tree: 選單項目樹狀結構
+Navigation Bar: 導覽列
+Navigation Bar Menu: 導覽列選單
+Navigation Bar Tour: 導覽列教學
+Next: 下一步
+Next Tour: 下一個導覽
+Paste Menu: 貼上選單
+Paste Menu Panel: 貼上選單面板
+Paste Menu Tour: 貼上選單導覽
+Paste Menu View: 貼上選單檢視
+PasteBar Menu: PasteBar 選單
+PasteBar Settings: PasteBar 設定
+PasteBar Settings Tour: PasteBar 設定導覽
+PasteBar Tour: PasteBar 導覽
+Previous: 上一步
+Priority Support: 優先支援
+Reset All Tours: 重設所有導覽
+Resizable Panel View: 可調整大小的面板檢視
+Return to the Main Screen: 返回主畫面
+Saved Clip Item: 已儲存的片段項目
+Security Settings: 安全性設定
+Selected Items Paste Menu: 已選取項目貼上選單
+Skip: 略過
+Skip All Tours: 略過所有導覽
+Skip Tour: 略過導覽
+Skip Update: 略過更新
+Start: 開始
+Start Next Tour: 開始下一個導覽
+Start Tour: 開始導覽
+Support and Feedback: 支援與意見回饋
+Tabs and Layout Menu: 分頁與版面配置選單
+Title on Popover: 彈出視窗標題
+Toggle Inactive Menu Items: 切換非使用中選單項目
+Toggle Pinned Board: 切換已釘選看板
+Toggle History Window: 切換歷史視窗
+Tour Completed: 導覽已完成
+Tour Skipped: 導覽已略過
+Tour completed: 導覽完成
+Tour skipped: 導覽已略過
+TourCanSkip: 可略過導覽
+User Preferences: 使用者偏好設定
+View Menu: 檢視選單
+Welcome to Paste Menu: 歡迎使用貼上選單
+Welcome to PasteBar: 歡迎使用 PasteBar
+Welcome to PasteBar Settings: 歡迎使用 PasteBar 設定
+WelcomeBody: 準備好使用 PasteBar 來簡化您的複製貼上工作流程了嗎！本導覽教學將帶您了解主要功能，並向您展示如何充分運用這個應用程式。讓我們從探索剪貼簿歷史面板開始吧。
+WelcomeDescription: 感謝您選擇我們的應用程式來簡化複製貼上工作流程並增強剪貼簿功能。為了協助您快速上手並充分運用 PasteBar 的各項功能，我們邀請您進行一段簡短的應用程式導覽。
+WelcomeTour: 讓我們從探索剪貼簿歷史面板開始。
+WelcomeTourCanSkip: 或者，若您偏好自行探索，可以<i>略過導覽</i>。您隨時可以從導覽列的<strong>說明 > 應用程式導覽教學</strong>選單中取得所有導覽。
+WelcomeTourDescription: 透過本導覽了解這個應用程式區塊的功能與特性。
+You have completed the tour: 您已完成導覽

--- a/packages/pastebar-app-ui/src/locales/lang/zhTW/history.yaml
+++ b/packages/pastebar-app-ui/src/locales/lang/zhTW/history.yaml
@@ -1,0 +1,42 @@
+All History Settings: 歷史記錄所有設定
+All done! History's been cleared.: 完成！歷史記錄已清除。
+Auto Update on Capture: 擷取時自動更新
+Auto-Clear Settings: 自動清除設定
+Capture History: 擷取歷史
+Clear: 清除
+Clear All: 全部清除
+Clear All History: 清除所有歷史記錄
+Clear History: 清除歷史記錄
+Confirm Clear All History: 確認清除所有歷史記錄
+Do you really want to remove ALL clipboard history items?: 確定要刪除所有剪貼簿歷史記錄項目嗎？
+Do you want to remove all recent clipboard history older than {{olderThen}} {{durationType}}: 是否要刪除所有早於 {{olderThen}} {{durationType}} 的最近剪貼簿歷史記錄？
+Do you want to remove clipboard history items older than {{olderThen}} {{durationType}}: 是否要刪除早於 {{olderThen}} {{durationType}} 的剪貼簿歷史記錄項目？
+Enable Capture History: 啟用歷史記錄擷取
+Enable Image Capture: 啟用圖片擷取
+Filters:
+  App Filters: 應用程式篩選器
+  Audio: 音訊
+  Clear Filters: 清除篩選器
+  Code: 程式碼
+  Emoji: 表情符號
+  Image: 圖片
+  Language Filters: 語言篩選器
+  Languages: 語言
+  Languages Filter: 語言篩選器
+  Languages Filters: 語言篩選器
+  Link: 連結
+  Pinned: 已釘選
+  Secret: 機密
+  Select Filters: 選擇篩選器
+  Source: 來源
+  Source Application: 來源應用程式
+  Source Filters: 來源篩選器
+  Starred: 已加星號
+  Text: 文字
+  Video: 影片
+Hide pinned history: 隱藏已釘選的歷史記錄
+History Settings: 歷史記錄設定
+Paste Menu: 貼上選單
+Select Filters: 選擇篩選器
+View pinned history: 檢視已釘選的歷史記錄
+'{{isAll}} Clipboard History': '{{isAll}} 剪貼簿歷史'

--- a/packages/pastebar-app-ui/src/locales/lang/zhTW/menus.yaml
+++ b/packages/pastebar-app-ui/src/locales/lang/zhTW/menus.yaml
@@ -1,0 +1,30 @@
+Add First Item: 新增第一個項目
+Add Item: 新增項目
+Add item: 新增項目
+Close Edit: 關閉編輯
+Create Menu: 建立選單
+Delete Menu: 刪除選單
+Disabled Item: 已停用項目
+Disabled Menu: 已停用選單
+Drag items to reorder, double click to rename: 拖曳項目可重新排序，雙擊可重新命名
+Enter menu label: 輸入選單標籤
+Find in menu: 在選單中搜尋
+Link to Clip: 連結至片段
+Menu: 選單
+Menu Item: 選單項目
+Menu Options: 選單選項
+Menu Type: 選單類型
+Menu is a link to a clip: 選單已連結至片段
+Menu is link to a clip and cannot be renamed. Please rename its linked clip.: 選單已連結至片段，無法重新命名。請重新命名其連結的片段。
+Menus: 選單
+New Disabled Menu: 新增已停用選單
+New Menu: 新增選單
+New Submenu: 新增子選單
+No Menu Items: 無選單項目
+'No {{hasActive}} menu items in': 在{{hasActive}}中無選單項目
+Select item to add a menu after: 選擇項目以在其後新增選單
+Separator: 分隔符號
+Submenu: 子選單
+Toggle inactive menu items: 切換非啟用選單項目
+active: 啟用
+menu items in: 選單項目於

--- a/packages/pastebar-app-ui/src/locales/lang/zhTW/navbar.yaml
+++ b/packages/pastebar-app-ui/src/locales/lang/zhTW/navbar.yaml
@@ -1,0 +1,44 @@
+Attach History: 附加歷史
+Audio Player: 音訊播放器
+Close History: 關閉歷史
+Close Main Window: 關閉主視窗
+Color Theme: 色彩主題
+GlobalSearch:
+  Auto Close on Copy & Paste: 複製貼上後自動關閉
+  Excludes clip or menu values: 排除片段或選單項目的值
+  Nothing found in boards.: 在看板中未找到任何結果。
+  Nothing found in clips, boards or menus.: 在片段、看板或選單中未找到任何結果。
+  Nothing found in clips.: 在片段中未找到任何結果。
+  Nothing found in menus.: 在選單中未找到任何結果。
+  Press / key to search: 按 / 鍵進行搜尋
+  Search: 搜尋
+  Search Name or Label Only: 僅搜尋名稱或標籤
+  Search Options: 搜尋選項
+  Type what you looking for: 輸入您要尋找的內容
+Help: 說明
+Language: 語言
+Lock: 鎖定
+Lock App Screen: 鎖定應用程式畫面
+Lock Screen: 鎖定螢幕
+Open PasteBar: 開啟 PasteBar
+Options: 選項
+Player: 播放器
+Show Always on Top: 永遠顯示於最上層
+Show Both Panels: 顯示兩個面板
+Show Clips Panel Only: 僅顯示片段面板
+Show Collections Name: 顯示收藏集名稱
+Show History Panel Only: 僅顯示歷史面板
+Swap Panels Layout: 交換面板版面配置
+Theme:
+  Dark: 深色
+  Light: 淺色
+  System: 系統
+View: 檢視
+Window:
+  Attach History Window: 附加歷史視窗
+  Attach Window: 附加視窗
+  Close Window: 關閉視窗
+  Maximize Window: 最大化視窗
+  Minimize Window: 最小化視窗
+  Pin Window: 釘選視窗
+  UnPin Window: 取消釘選視窗

--- a/packages/pastebar-app-ui/src/locales/lang/zhTW/pinned.yaml
+++ b/packages/pastebar-app-ui/src/locales/lang/zhTW/pinned.yaml
@@ -1,0 +1,3 @@
+Hide Pinned: 隱藏已釘選
+Pin: 釘選
+Show Pinned: 顯示已釘選

--- a/packages/pastebar-app-ui/src/locales/lang/zhTW/settings.yaml
+++ b/packages/pastebar-app-ui/src/locales/lang/zhTW/settings.yaml
@@ -1,0 +1,220 @@
+'<strong>{{screenLockPassCodeLength}}</strong> digits passcode is set.': 已設定 <strong>{{screenLockPassCodeLength}}</strong> 位數字密碼。
+Activation Success: 啟用成功
+Add a star to the copied text when you copy it twice within 1 second. This allows you to quickly add copied text or links to your favorites and easily find it in the clipboard history.: 在 1 秒內複製兩次文字時自動加星號。這讓您可以快速將複製的文字或連結加入我的最愛，並在剪貼簿歷史中輕鬆找到。
+Add an unlimited number of tabs within each collection for better organization and easy access.: 在每個收藏集中新增無限數量的分頁，以便更好地整理和快速存取。
+'Add an unlimited number of tabs within each collection for better organization and easy access.                                ': '在每個收藏集中新增無限數量的分頁，以便更好地整理和快速存取。                                '
+Advanced settings: 進階設定
+Already Active: 已啟用
+Application Auto Start: 應用程式自動啟動
+Application Color Theme: 應用程式色彩主題
+Application UI Color Theme: 應用程式介面色彩主題
+Application UI Fonts Scale: 應用程式介面字型縮放
+Application UI Language: 應用程式介面語言
+Applications listed below will not have their copy to clipboard action captured in clipboard history. Case insensitive.: 以下列出的應用程式複製到剪貼簿的動作將不會被記錄在剪貼簿歷史中。不區分大小寫。
+Apply and Restart: 套用並重新啟動
+Are you sure you want to go back to the default data folder? This will remove the custom location setting.: 您確定要回復到預設資料夾嗎？這將移除自訂位置設定。
+Are you sure you want to revert to the default database location? The application will restart.: 您確定要還原至預設資料庫位置嗎？應用程式將重新啟動。
+Are you sure you want to set "{{path}}" as the new data folder? The application will restart.: 您確定要將「{{path}}」設定為新的資料夾嗎？應用程式將重新啟動。
+Are you sure you want to {{operation}} the database to "{{path}}"? The application will restart.: 您確定要將資料庫{{operation}}至「{{path}}」嗎？應用程式將重新啟動。
+Auto Disable History Capture when Screen Unlocked: 螢幕解鎖時自動停用歷史擷取
+Auto Lock Application Screen on User Inactivity: 使用者閒置時自動鎖定應用程式螢幕
+Auto Lock Screen on User Inactivity: 使用者閒置時自動鎖定螢幕
+Auto Lock the Screen on User Inactivity: 使用者閒置時自動鎖定螢幕
+Auto Masking Words List: 自動遮蔽詞清單
+Auto update on capture: 擷取時自動更新
+Auto-Clear Settings: 自動清除設定
+Auto-Generate Link Card Preview: 自動產生連結卡片預覽
+Auto-Preview Link on Hover: 懸停時自動預覽連結
+Auto-Star on Double Copy: 雙次複製時自動加星號
+Auto-Trim Spaces on Capture: 擷取時自動修剪空格
+Auto-Update on Capture: 擷取時自動更新
+Auto-delete clipboard history after: 自動刪除剪貼簿歷史於
+Automatically create link card preview in the clipboard history. This allows to quickly view website details without opening or pasting the link.: 自動在剪貼簿歷史中建立連結卡片預覽。這讓您無需開啟或貼上連結即可快速查看網站詳情。
+Back: 返回
+Capture History: 擷取歷史
+Capture History Text Length Limits: 擷取歷史文字長度限制
+Change Custom Data Folder...: 變更自訂資料夾...
+Change Directory...: 變更目錄...
+Change Selected Folder...: 變更選定的資料夾...
+Change the application UI font size scale: 變更應用程式介面字型大小縮放
+Change the application UI language: 變更應用程式介面語言
+Change the application user interface color theme: 變更應用程式使用者介面色彩主題
+Change the application user interface font size scale: 變更應用程式使用者介面字型大小縮放
+Change the application user interface language: 變更應用程式使用者介面語言
+Changing the database location requires an application restart to take effect.: 變更資料庫位置需要重新啟動應用程式才能生效。
+Clip Notes Popup Maximum Dimensions: 片段筆記彈出視窗最大尺寸
+Clipboard History Settings: 剪貼簿歷史設定
+'Complete details:': '完整詳情：'
+Configure settings to automatically delete clipboard history items after a specified duration.: 設定在指定時間後自動刪除剪貼簿歷史項目。
+ConfirmRevertToDefaultDbPathMessage: 您確定要還原至預設資料位置嗎？您的應用程式資料將移動至預設路徑。
+Copy data: 複製資料
+Copy database file: 複製資料庫檔案
+Create a preview card on link hover in the clipboard history. This allows you to preview the link before opening or pasting it.: 在剪貼簿歷史中懸停連結時建立預覽卡片。這讓您可以在開啟或貼上連結前先預覽。
+Create an unlimited number of collections to organize your clips and menus.: 建立無限數量的收藏集來整理您的片段和選單。
+Current data folder: 目前資料夾
+Current data location: 目前資料位置
+Current database location: 目前資料庫位置
+Custom: 自訂
+Custom Application Data Location: 自訂應用程式資料位置
+Custom Database Location: 自訂資料庫位置
+Custom data location is active. You can change it or revert to the default location. Changes require an application restart.: 自訂資料位置已啟用。您可以變更或還原至預設位置。變更需要重新啟動應用程式。
+Custom themes: 自訂主題
+Decrease UI Font Size: 縮小介面字型
+Default: 預設
+Disable Image Capture: 停用圖片擷取
+Disable capturing and storing images from clipboard: 停用從剪貼簿擷取及儲存圖片
+Display clipboard history capture toggle on the locked application screen. This allows you to control history capture settings directly from the lock screen.: 在已鎖定的應用程式螢幕上顯示剪貼簿歷史擷取開關。這讓您可以直接從鎖定螢幕控制歷史擷取設定。
+Display disabled collections name on the navigation bar collections menu: 在導覽列收藏集選單中顯示已停用的收藏集名稱
+Display disabled collections name on the navigation bar under collections menu: 在導覽列收藏集選單下方顯示已停用的收藏集名稱
+Display full name of selected collection on the navigation bar: 在導覽列顯示所選收藏集的完整名稱
+Do you want to attempt to move the database file from "{{customPath}}" back to the default location?: 您要嘗試將資料庫檔案從「{{customPath}}」移回預設位置嗎？
+Drag and drop to prioritize languages for detection. The higher a language is in the list, the higher its detection priority.: 拖放以設定語言偵測優先順序。清單中越靠上的語言，其偵測優先順序越高。
+Email: 電子郵件
+Email is not valid: 電子郵件格式無效
+'Email:': '電子郵件：'
+Emails do not match: 電子郵件不相符
+Enable Auto Start: 啟用自動啟動
+Enable Clip Title Hover Show with Delay: 啟用片段標題延遲懸停顯示
+Enable application auto start on system boot: 啟用系統開機時應用程式自動啟動
+Enable auto lock the application screen after a certain period of inactivity, to prevent unauthorized access to your data.: 啟用在一定閒置時間後自動鎖定應用程式螢幕，以防止未授權存取您的資料。
+Enable auto lock the application screen when user not active: 使用者未活動時啟用自動鎖定應用程式螢幕
+Enable auto trim spaces on history capture: 啟用歷史擷取時自動修剪空格
+Enable auto update on capture: 啟用擷取時自動更新
+Enable custom data location to store application data in a directory of your choice instead of the default location.: 啟用自訂資料位置，將應用程式資料儲存在您選擇的目錄中，而非預設位置。
+Enable history capture: 啟用歷史擷取
+Enable programming language detection: 啟用程式語言偵測
+Enable screen unlock requirement on app launch for enhanced security, safeguarding data from unauthorized access.: 啟用應用程式啟動時的螢幕解鎖要求，以提升安全性，保護資料免受未授權存取。
+Enter Passcode length: 輸入密碼長度
+Enter new directory path or leave empty for default on next revert: 輸入新目錄路徑，或留空以在下次還原時使用預設路徑
+Enter recovery password to reset passcode.: 輸入復原密碼以重設密碼。
+Enter your <strong>{{screenLockPassCodeLength}} digits</strong> passcode: 輸入您的 <strong>{{screenLockPassCodeLength}} 位數字</strong>密碼
+Entered Passcode is invalid: 輸入的密碼無效
+Excluded Apps List: 排除的應用程式清單
+Execute Web Requests: 執行網路請求
+Execute terminal or shell commands directly from PasteBar clip and copy the results to the clipboard.: 直接從 PasteBar 片段執行終端機或 Shell 指令，並將結果複製到剪貼簿。
+'Expires:': '到期：'
+Failed to revert to default database location.: 還原至預設資料庫位置失敗。
+Failed to select directory: 選擇目錄失敗
+Forgot Passcode ? Enter your recovery password to reset the passcode.: 忘記密碼？請輸入您的復原密碼以重設密碼。
+Forgot passcode ?: 忘記密碼？
+Forgot?: 忘記了？
+Forgot? Reset using Password: 忘記了？使用密碼重設
+Get priority email support from us to resolve any issues or questions you may have about PasteBar.: 取得我們的優先電子郵件支援，解決您對 PasteBar 的任何問題或疑問。
+'Hint: {{screenLockRecoveryPasswordMasked}}': '提示：{{screenLockRecoveryPasswordMasked}}'
+If a database file already exists at the default location, do you want to overwrite it? Choosing "Cancel" will skip moving the file if an existing file is found.: 預設位置已有資料庫檔案，是否要覆蓋？選擇「取消」將在找到現有檔案時略過移動。
+Incorrect passcode.: 密碼不正確。
+Increase UI Font Size: 放大介面字型
+Issued: 發行日期
+Large: 大
+List each application name or window identifier on a new line.: 每行輸入一個應用程式名稱或視窗識別碼。
+List each word or sentence on a new line.: 每行輸入一個詞語或句子。
+Lock Screen Clipboard History Capture Control: 鎖定螢幕剪貼簿歷史擷取控制
+Lock Screen PassCode: 鎖定螢幕密碼
+Lock Screen Passcode: 鎖定螢幕密碼
+Manage Collections: 管理收藏集
+Maximum 10 digits: 最多 10 位數字
+Maximum devices: 最多裝置數
+Medium: 中
+Minimal 4 digits: 最少 4 位數字
+Minimize Window: 最小化視窗
+Minimum number of lines to trigger detection: 觸發偵測的最少行數
+Move data: 移動資料
+Move database file: 移動資料庫檔案
+Name: 名稱
+New Data Directory Path: 新資料目錄路徑
+New Database Directory Path: 新資料庫目錄路徑
+Open Security Settings: 開啟安全性設定
+Operation when applying new path: 套用新路徑時的操作
+Passcode digits remaining: 剩餘密碼位數
+Passcode is locked.: 密碼已鎖定。
+Passcode is not set: 尚未設定密碼
+Passcode is not valid: 密碼無效
+Passcode length: 密碼長度
+Passcode mismatch: 密碼不相符
+Passcode reset is locked.: 密碼重設已鎖定。
+Passcode successfully verified: 密碼驗證成功
+Passcode verification error: 密碼驗證錯誤
+Passcode verification is locked.: 密碼驗證已鎖定。
+Password is incorrect.: 密碼不正確。
+Password is incorrect. <br/>{{screenLockRecoveryPasswordMasked}}: 密碼不正確。<br/>{{screenLockRecoveryPasswordMasked}}
+'Password is incorrect. Hint: {{screenLockRecoveryPasswordMasked}}': '密碼不正確。提示：{{screenLockRecoveryPasswordMasked}}'
+'Password is incorrect. Masked password is: {{screenLockRecoveryPasswordMasked}}': '密碼不正確。遮蔽密碼為：{{screenLockRecoveryPasswordMasked}}'
+Password is incorrect. {{screenLockRecoveryPasswordMasked}}: 密碼不正確。{{screenLockRecoveryPasswordMasked}}
+Passwords do not match: 密碼不相符
+PasteBar Settings: PasteBar 設定
+Pin Window: 釘選視窗
+Pin on Top Window: 釘選視窗至最上層
+Please set up a Passcode and recovery password in Security Settings to enable Screen Lock and ensure better security.: 請在安全性設定中設定密碼及復原密碼，以啟用螢幕鎖定並確保更高的安全性。
+Please try again: 請再試一次
+Preview current popup size on hover.: 懸停時預覽目前彈出視窗大小。
+Prioritize Language Detection: 語言偵測優先順序
+Priority support: 優先支援
+Programming Language Detection: 程式語言偵測
+Programming Language Selection: 程式語言選擇
+Protect your data by requiring screen unlock authentication whenever the application starts.: 透過要求應用程式啟動時進行螢幕解鎖驗證來保護您的資料。
+Recovery Password for Lock Screen Passcode: 鎖定螢幕密碼的復原密碼
+Recovery password is set.: 復原密碼已設定。
+Refresh Application UI: 重新整理應用程式介面
+Refresh UI: 重新整理介面
+Require Screen Unlock at Application Start: 應用程式啟動時要求螢幕解鎖
+Require screen unlock at application launch to enhance security. This setting ensures that only authorized users can access the application, protecting your data from unauthorized access right from the start.: 要求應用程式啟動時螢幕解鎖以提升安全性。此設定確保只有授權的使用者可以存取應用程式，從一開始就保護您的資料免受未授權存取。
+Reset Font Size: 重設字型大小
+Revert to Default: 還原為預設值
+Revert to Default and Restart: 還原為預設值並重新啟動
+Run Terminal or Shell Commands: 執行終端機或 Shell 指令
+Scrape and parse websites or API responses using built-in web scraping tools and copy the extracted data to the clipboard.: 使用內建的網頁擷取工具擷取並解析網站或 API 回應，並將提取的資料複製到剪貼簿。
+'Scrape and parse websites or API responses using built-in web scraping tools and copy the extracted data to the clipboard.                                ': '使用內建的網頁擷取工具擷取並解析網站或 API 回應，並將提取的資料複製到剪貼簿。                                '
+Security: 安全性
+Security Settings: 安全性設定
+Select Custom Data Folder...: 選擇自訂資料夾...
+Select Data Folder: 選擇資料夾
+Select Data Folder...: 選擇資料夾...
+Select a custom location to store your application data instead of the default location.: 選擇自訂位置來儲存應用程式資料，而非使用預設位置。
+Selected data folder: 已選擇的資料夾
+Selected new data folder: 已選擇新的資料夾
+Selected new data folder for change: 已選擇用於變更的新資料夾
+Send HTTP requests to web APIs or services and copy the response data to the clipboard.: 向網路 API 或服務發送 HTTP 請求，並將回應資料複製到剪貼簿。
+Sensitive words or sentences listed below will automatically be masked if found in the copied text. Case insensitive.: 如果在複製的文字中找到以下列出的敏感詞語或句子，將自動遮蔽。不區分大小寫。
+Set a passcode to unlock the locked screen and protect your data from unauthorized access.: 設定密碼以解鎖鎖定的螢幕，並保護您的資料免受未授權存取。
+Set a recovery password to easily reset your lock screen passcode if forgotten. Your password will be securely stored in your device's OS storage.: 設定復原密碼，以便忘記鎖定螢幕密碼時輕鬆重設。您的密碼將安全地儲存在裝置的作業系統儲存空間中。
+Setting a custom database location requires an application restart to take effect.: 設定自訂資料庫位置需要重新啟動應用程式才能生效。
+Settings: 設定
+Show Clipboard History Capture Control on Lock Screen: 在鎖定螢幕上顯示剪貼簿歷史擷取控制
+Show Disable History Capture When Screen Locked: 螢幕鎖定時顯示停用歷史擷取
+Show Disabled Collections: 顯示已停用的收藏集
+Show clipboard history capture toggle when the application screen is locked. This allow you to control capturing history settings from the application locked screen.: 當應用程式螢幕鎖定時顯示剪貼簿歷史擷取開關。這讓您可以從應用程式鎖定螢幕控制擷取歷史設定。
+Show collection name on the navbar: 在導覽列顯示收藏集名稱
+Show disabled collections on the navbar list: 在導覽列清單中顯示已停用的收藏集
+Skip auto start prompt on app launch: 應用程式啟動時略過自動啟動提示
+Small: 小
+Stop Words List: 停用詞清單
+Swap Panels Layout: 交換面板配置
+Switch the layout position of panels in Clipboard History and Paste Menu views: 在剪貼簿歷史和貼上選單檢視中切換面板的配置位置
+Thank you again for using PasteBar.: 再次感謝您使用 PasteBar。
+Thank you for testing! 🙌: 感謝您的測試！🙌
+The selected folder is not empty and does not contain PasteBar data files. Do you want to create a "pastebar-data" subfolder to store the data?: 選定的資料夾不是空的，且不包含 PasteBar 資料檔案。您要建立「pastebar-data」子資料夾來儲存資料嗎？
+The selected folder is not empty. Do you want to create a "pastebar-data" subfolder to store the data?: 選定的資料夾不是空的。您要建立「pastebar-data」子資料夾來儲存資料嗎？
+This folder already contains PasteBar data. The application will use this existing data after restart.: 此資料夾已包含 PasteBar 資料。應用程式重新啟動後將使用這些現有資料。
+This option lets you control the display and timing of hover notes on clips. You can choose to show notes instantly or with a delay to prevent unintended popups.: 此選項讓您控制片段懸停筆記的顯示和時機。您可以選擇立即顯示筆記或延遲顯示，以防止意外彈出。
+This option lets you customize the maximum width and height of the popup that displays clip notes, ensuring it fits comfortably within your desired size.: 此選項讓您自訂顯示片段筆記之彈出視窗的最大寬度和高度，確保其大小符合您的需求。
+This option lets you customize the minimum and maximum length of text that can be captured in the clipboard history. Setting either value to 0 makes that limit unlimited.: 此選項讓您自訂剪貼簿歷史中可擷取文字的最小和最大長度。將任一值設為 0 表示該限制為無限制。
+To downgrade your current version, please visit: 若要降級目前版本，請造訪
+'To downgrade, please visit: ': '若要降級，請造訪：'
+To ensure the best detection accuracy, please select up to 7 languages. Limiting choices improves precision.: 為確保最佳偵測準確性，請最多選擇 7 種語言。限制選擇可提高精確度。
+Today: 今天
+Tomorrow: 明天
+Try after <strong>{{resetPassCodeNextDelay}}</strong> seconds: 請於 <strong>{{resetPassCodeNextDelay}}</strong> 秒後再試
+Try again after <strong>{{resetPassCodeNextDelay}}</strong> seconds: 請於 <strong>{{resetPassCodeNextDelay}}</strong> 秒後再試一次
+UI Language: 介面語言
+UnPin Window: 取消釘選視窗
+Unlimited Collections: 無限收藏集
+Unlimited Tabs per Collection: 每個收藏集無限分頁
+Unlimited paste history: 無限貼上歷史
+Use Password: 使用密碼
+Use new location: 使用新位置
+User Preferences: 使用者偏好設定
+Web Scraping and Parsing: 網頁擷取與解析
+Words or sentences listed below will not be captured in clipboard history if found in the copied text. Case insensitive.: 如果在複製的文字中找到以下列出的詞語或句子，將不會記錄在剪貼簿歷史中。不區分大小寫。
+none: 無
+passcode reset: 密碼重設
+password reset: 密碼重設

--- a/packages/pastebar-app-ui/src/locales/lang/zhTW/settings2.yaml
+++ b/packages/pastebar-app-ui/src/locales/lang/zhTW/settings2.yaml
@@ -1,0 +1,82 @@
+App restart required: 需要重新啟動應用程式
+Application Starts with Main Window Hidden: 應用程式啟動時隱藏主視窗
+Auto-close window after action: 操作後自動關閉視窗
+Boards, saved clips and menu items panel visible: 看板、已儲存片段和選單項目面板可見
+Both clipboard history and saved clips panels visible: 剪貼簿歷史和已儲存片段面板均可見
+Change: 變更
+Click Set/Change button to start recording: 點擊「設定/變更」按鈕開始錄製
+Clipboard history panel visible: 剪貼簿歷史面板可見
+Configure how the system tray icon responds to mouse clicks: 設定系統匣圖示對滑鼠點擊的回應方式
+Configure the behavior of the Quick Paste window when selecting items: 設定快速貼上視窗在選取項目時的行為
+Configure which items to preserve when clearing clipboard history (both manual and auto-clear operations).: 設定清除剪貼簿歷史時要保留哪些項目（包含手動與自動清除操作）。
+Control which panels are visible in the main window: 控制主視窗中哪些面板可見
+Copy items only (no auto-paste): 僅複製項目（不自動貼上）
+Copy only from menu items: 僅從選單項目複製
+Default Note Icon Type: 預設筆記圖示類型
+Disable left-click context menu: 停用左鍵快顯選單
+Display navbar items only when the mouse hovers over the navigation bar to minimize visible UI elements: 僅在滑鼠停留於導覽列時顯示導覽列項目，以減少可見的 UI 元素
+Display persistent icons on clips that have notes to improve visual organization and make notes easier to discover.: 在含有筆記的片段上顯示固定圖示，以改善視覺組織並使筆記更容易被發現。
+Double-click toggles app visibility: 雙擊切換應用程式顯示狀態
+Double-clicking the tray icon shows or hides the main application window: 雙擊系統匣圖示可顯示或隱藏主應用程式視窗
+Enable simplified, less boxy layout for a cleaner and more streamlined interface design: 啟用簡化、較少方塊感的版面配置，以獲得更簡潔流暢的介面設計
+Enable single-click to copy/paste clipboard history items and saved clips instead of requiring double-click.: 啟用單擊即可複製/貼上剪貼簿歷史項目和已儲存片段，無需雙擊。
+Enabling either left-click option will disable the context menu to ensure proper functionality.: 啟用任一左鍵選項將停用快顯選單以確保功能正常運作。
+Global System OS Hotkeys: 全域系統快捷鍵
+Hide Collections Navbar: 隱藏收藏集導覽列
+Hide collections menu dropdown on the navigation bar: 隱藏導覽列上的收藏集選單下拉列表
+Hide collections menu on the navbar: 在導覽列上隱藏收藏集選單
+Hide the App Dock Icon: 隱藏應用程式 Dock 圖示
+History Item Preview Max Lines: 歷史項目預覽最大行數
+'How to set hotkeys:': '如何設定快捷鍵：'
+Keep Items on Clear: 清除時保留項目
+Keep Pinned Items: 保留已釘選項目
+Keep Starred Items: 保留已加星號項目
+? Keep the main application window hidden when the app restarts. You can reopen it using the menu bar or taskbar menu, or using global hotkeys.
+: 應用程式重新啟動時保持主視窗隱藏。您可以使用選單列或工作列選單，或使用全域快捷鍵重新開啟它。
+Left-click toggles app visibility: 左鍵點擊切換應用程式顯示狀態
+Left-clicking the tray icon shows or hides the main application window: 左鍵點擊系統匣圖示可顯示或隱藏主應用程式視窗
+No keys set: 未設定按鍵
+'Note: At least one panel must remain visible in main window.': '注意：主視窗中至少須保留一個面板可見。'
+Panel Visibility: 面板可見性
+PasteBar Quick Paste: PasteBar 快速貼上
+Preserve pinned items when clearing history: 清除歷史時保留已釘選項目
+Preserve starred items when clearing history: 清除歷史時保留已加星號項目
+Press Backspace/Delete to clear the hotkey: 按 Backspace/Delete 清除快捷鍵
+Press Enter to confirm or Escape to cancel: 按 Enter 確認或按 Escape 取消
+Press keys: 按下按鍵
+Press your desired key combination (e.g., Ctrl+Shift+V): 按下您想要的按鍵組合（例如：Ctrl+Shift+V）
+Press your key combination...: 按下您的按鍵組合...
+Prevents the context menu from appearing when left-clicking the tray icon: 防止左鍵點擊系統匣圖示時出現快顯選單
+Preview Max Lines: 預覽最大行數
+Quick Paste Window: 快速貼上視窗
+Quick Paste Window Options: 快速貼上視窗選項
+Recording...: 錄製中...
+? Remove PasteBar app icon from the macOS Dock while keeping the app running in the background. The app remains accessible via the menu bar icon. Requires an app restart to take effect.
+: 從 macOS Dock 中移除 PasteBar 應用程式圖示，同時保持應用程式在背景執行。應用程式仍可透過選單列圖示存取。需要重新啟動應用程式才能生效。
+Set: 設定
+Set system OS hotkeys to show/hide the main app window and quick paste window. Supports up to 3-key combinations.: 設定系統快捷鍵以顯示/隱藏主應用程式視窗和快速貼上視窗。支援最多 3 鍵組合。
+Set the maximum number of lines to display in the preview of a history item: 設定歷史項目預覽中顯示的最大行數
+Show Boards and Clips Panel Only: 僅顯示看板和片段面板
+Show Both Panels: 顯示兩個面板
+Show History Panel Only: 僅顯示歷史面板
+Show Navbar Items Hover: 懸停時顯示導覽列項目
+Show Note Icons on Clips: 在片段上顯示筆記圖示
+Show Simplified Layout: 顯示簡化版面配置
+Show collections menu on the navbar: 在導覽列上顯示收藏集選單
+Show navbar elements on hover only: 僅在懸停時顯示導覽列元素
+Show/Hide Main App Window: 顯示/隱藏主應用程式視窗
+Show/Hide Quick Paste Window: 顯示/隱藏快速貼上視窗
+Simplified Panel Layout: 簡化面板版面配置
+Single Click Copy/Paste: 單擊複製/貼上
+Single Click Copy/Paste action: 單擊複製/貼上操作
+Set keyboard focus with a single click. Disables single-click copy/paste if set.: 單擊設定鍵盤焦點。若設定此選項，將停用單擊複製/貼上功能。
+Single-Click Keyboard Focus: 單擊鍵盤焦點
+This sets the default icon type for new clips with notes. You can customize individual clips via the context menu.: 此設定為含有筆記的新片段設定預設圖示類型。您可以透過快顯選單自訂個別片段。
+Tray Icon Behavior on Windows: Windows 系統匣圖示行為
+? When enabled, clicking menu items will only copy content to clipboard instead of auto-pasting. This gives you more control over when and where content is pasted.
+: 啟用後，點擊選單項目只會將內容複製到剪貼簿，而不會自動貼上。這讓您對內容貼上的時機和位置有更多控制。
+? When enabled, clicking or pressing Enter on items in Quick Paste window will only copy them to clipboard without automatically pasting.
+: 啟用後，在快速貼上視窗中點擊或按 Enter 鍵選取項目，只會將其複製到剪貼簿，而不會自動貼上。
+? When enabled, single click will copy/paste items in Quick Paste window. If global single click is also enabled, both settings work together.
+: 啟用後，在快速貼上視窗中單擊即可複製/貼上項目。若全域單擊功能也已啟用，兩個設定將同時作用。
+When enabled, the Quick Paste window will automatically close after copying or pasting an item.: 啟用後，複製或貼上項目後，快速貼上視窗將自動關閉。

--- a/packages/pastebar-app-ui/src/locales/lang/zhTW/specailCopyPaste.yaml
+++ b/packages/pastebar-app-ui/src/locales/lang/zhTW/specailCopyPaste.yaml
@@ -1,0 +1,1 @@
+Special Settings: 特殊設定

--- a/packages/pastebar-app-ui/src/locales/lang/zhTW/specialCopyPaste.yaml
+++ b/packages/pastebar-app-ui/src/locales/lang/zhTW/specialCopyPaste.yaml
@@ -1,0 +1,74 @@
+Add Current Date/Time: 加入目前日期/時間
+Add Line Numbers: 加入行號
+Add One Line Feed: 加入一個換行符
+Add Two Line Feeds: 加入兩個換行符
+Base64 Decode: Base64 解碼
+Base64 Encode: Base64 編碼
+CSV: CSV
+CSV to JSON: CSV 轉 JSON
+CSV to Markdown Table: CSV 轉 Markdown 表格
+Capitalize Case: 首字母大寫
+Code Formatting: 程式碼格式化
+Count Characters: 計算字元數
+Count Lines: 計算行數
+Count Sentences: 計算句子數
+Count Words: 計算單詞數
+Data Conversion: 資料轉換
+Drag and drop category to prioritize its order in the special copy/paste menu.: 拖放類別以在特殊複製/貼上選單中調整其優先順序。
+Enable All: 全部啟用
+Enable special text transformation options for clipboard history items: 為剪貼簿歷史項目啟用特殊文字轉換選項
+Enabled Operations: 已啟用的操作
+Encode/Decode: 編碼/解碼
+Format Converter: 格式轉換器
+HTML: HTML
+HTML Decode: HTML 解碼
+HTML Encode: HTML 編碼
+HTML to Markdown: HTML 轉 Markdown
+HTML to Plain Text: HTML 轉純文字
+HTML to React Component: HTML 轉 React 元件
+HTML to React JSX: HTML 轉 React JSX
+HTML to Text: HTML 轉文字
+JSON: JSON
+JSON Stringify: JSON 字串化
+JSON to CSV: JSON 轉 CSV
+JSON to Markdown Table: JSON 轉 Markdown 表格
+JSON to TOML: JSON 轉 TOML
+JSON to XML: JSON 轉 XML
+JSON to YAML: JSON 轉 YAML
+Markdown: Markdown
+Markdown to HTML: Markdown 轉 HTML
+Markdown to Text: Markdown 轉文字
+Operations: 操作
+PascalCase: PascalCase
+Prioritize Category Order: 調整類別顯示優先順序
+PrioritizeCategoryOrderNote: 拖放類別以調整其在特殊複製/貼上選單中的顯示順序。
+Remove Duplicate Lines: 移除重複行
+Remove Extra Spaces: 移除多餘空格
+Remove Line Feeds: 移除換行符
+Reverse Text: 反轉文字
+Select Operations: 選擇操作
+Sentence case: 句子大小寫
+Sort Lines Alphabetically: 依字母順序排列行
+Special Copy: 特殊複製
+Special Copy/Paste Operations: 特殊複製/貼上操作
+Special Paste: 特殊貼上
+Special Settings: 特殊設定
+TOML: TOML
+TOML to JSON: TOML 轉 JSON
+Text Case: 文字大小寫
+Text Tools: 文字工具
+Title Case: 標題大小寫
+Trim White Space: 修剪空白
+UPPER CASE: 大寫
+URL Decode: URL 解碼
+URL Encode: URL 編碼
+Whitespace & Lines: 空白與行
+XML: XML
+XML to JSON: XML 轉 JSON
+YAML: YAML
+YAML to JSON: YAML 轉 JSON
+camelCase: camelCase
+iNVERT cASE: 反轉大小寫
+kebab-case: kebab-case
+lower case: 小寫
+snake_case: snake_case

--- a/packages/pastebar-app-ui/src/locales/lang/zhTW/templates.yaml
+++ b/packages/pastebar-app-ui/src/locales/lang/zhTW/templates.yaml
@@ -1,0 +1,24 @@
+Create New Template: 建立新範本
+Create Template: 建立範本
+Enter template content...: 輸入範本內容...
+Enter template name (e.g., "signature", "email"): 輸入範本名稱（例如：「簽名」、「電子郵件」）
+Global: 全域
+Global Template: 全域範本
+Global Templates: 全域範本
+Preview usage: 預覽用法
+Template Usage: 範本用法
+Template name already exists: 範本名稱已存在。請選擇不同的名稱。
+Template name cannot be changed after creation. Delete and recreate to change name.: 範本名稱建立後無法變更。若要變更名稱，請刪除後重新建立。
+Use Global Template: 使用全域範本
+addTemplateButton: 新增範本
+confirmDeleteTemplateMessage: 您確定要刪除全域範本「{{name}}」嗎？
+confirmDeleteTemplateTitle: 確認刪除
+deleteTemplateButtonTooltip: 刪除範本
+enableGlobalTemplatesLabel: 啟用全域範本
+globalTemplatesDescription: 管理可重複使用的文字片段，可使用 {{template_name}} 插入至任何片段中。
+globalTemplatesTitle: 全域範本
+localTemplateConflictWarning: 也存在名為「{{label}}」的全域範本。本地範本將在此片段的表單中優先使用。
+noGlobalTemplatesYet: 尚未定義任何全域範本。點擊「新增範本」來建立一個。
+templateEnabledLabel: 已啟用
+templateNameLabel: 名稱
+templateValueLabel: 值

--- a/packages/pastebar-app-ui/src/locales/lang/zhTW/tours.yaml
+++ b/packages/pastebar-app-ui/src/locales/lang/zhTW/tours.yaml
@@ -1,0 +1,241 @@
+HISTORY_PANEL_TOUR:
+  - element: '#side-panel_tour'
+    popover:
+      title: 剪貼簿歷史面板
+      description: 此面板顯示您複製的剪貼簿歷史，方便稍後存取。滾動瀏覽歷史、搜尋內容，或依類型篩選。您可以調整此面板的大小以獲得自訂的檢視方式。
+      prefferedSide: right
+  - element: '#history-find_tour'
+    popover:
+      title: 尋找並篩選歷史
+      description: 使用搜尋功能快速找到剪貼簿歷史中的特定項目。依類型（文字、圖片或連結）篩選結果，輕鬆定位您需要的內容。再次複製找到的項目，或將其儲存至看板。
+      prefferedSide: bottom
+      alignment: center
+  - element: '#history-list_tour .history-item'
+    popover:
+      title: 剪貼簿歷史項目
+      description: 剪貼簿歷史中的每個項目代表您先前複製的內容。<b>雙擊</b>項目或點擊圖示可將其複製回剪貼簿。<b>按住並拖曳</b>可在看板面板上建立已儲存的片段。<b>右鍵點擊</b>項目可在右鍵選單中查看更多選項。
+      prefferedSide: right
+  - element: '#tabs-history_tour'
+    meta:
+      closeTourCssPosition: hidden
+    popover:
+      title: 歷史/選單導覽分頁
+      description: 在剪貼簿歷史與貼上選單之間切換，輕鬆管理並存取您的內容。
+      alignment: center
+      prefferedSide: top
+  - element: '#history-menu-button_tour'
+    meta:
+      closeTourCssPosition: hidden
+    popover:
+      title: 歷史已選項目選單
+      description: 使用此選單管理剪貼簿歷史中已選取的項目。您可以<b>多選</b>項目、取消全選、新增至看板、刪除，或清除特定日期的歷史記錄。
+      alignment: end
+      prefferedSide: right
+  - element: .panel-resize_tour
+    popover:
+      title: 可調整大小的面板檢視
+      description: 透過調整面板檢視的大小來自訂工作區，以符合您的偏好。將<b>滑鼠懸停</b>在面板邊緣，直到出現調整大小的游標，再<b>點擊並拖曳</b>以調整面板大小。
+      prefferedSide: right
+
+DASHBOARD_CLIPS_TOUR:
+  - element: .clips-dashboard-panel_tour
+    meta:
+      closeTourCssPosition: hidden
+    popover:
+      title: 儀表板面板
+      description: 此面板提供一個集中樞紐，用於整理和管理您已儲存的片段。建立自訂分頁和看板來組織您的內容。從剪貼簿歷史<b>拖放</b>項目以建立新片段。使用分頁在不同的看板類別之間切換。
+      prefferedSide: left
+  - element: '#dashboard-tabs_tour'
+    popover:
+      title: 儀表板分頁
+      description: 建立自訂分頁，並用來在儀表板的不同區段之間導覽。在類別之間切換，以快速管理並存取您的片段和內容。
+      alignment: center
+      prefferedSide: bottom
+  - element: '#dashboard-tabs-create-button_tour'
+    popover:
+      title: 建立儀表板項目
+      description: 為您的儀表板建立新項目。新增片段、看板或自訂分頁，以整理您的內容。
+      alignment: end
+      prefferedSide: bottom
+  - element: '#dashboard-tabs-context-menu_tour'
+    popover:
+      title: 分頁與版面配置選單
+      description: <b>右鍵點擊</b>分頁或<b>點擊選單圖示</b>，以整理版面配置並管理分頁。您可以編輯現有分頁，或變更儀表板版面以符合您的工作流程偏好。
+      alignment: end
+      prefferedSide: bottom
+  - element: .board-panel_tour
+    popover:
+      title: 看板面板
+      description: 此看板面板讓您整理已儲存的片段，以便快速輕鬆地存取。從剪貼簿歷史<b>拖放</b>項目。使用看板有效率地分類和管理您的內容。
+      alignment: center
+      prefferedSide: right
+  - element: .board-panel-header_tour
+    popover:
+      title: 看板面板標題
+      description: <b>雙擊</b>標題可快速展開看板面板，或<b>右鍵點擊</b>以查看其他選項來自訂和管理看板。
+      alignment: start
+      prefferedSide: right
+  - element: .clip_tour
+    popover:
+      title: 已儲存的片段項目
+      description: 快速存取已儲存的片段內容。<b>雙擊</b>或<b>點擊剪貼簿圖示</b>即可複製。<b>長按</b>以重新排列項目，或<b>右鍵點擊</b>查看更多選項來自訂和整理您的片段。
+      alignment: start
+      prefferedSide: right
+  - element: .panel-resize_tour
+    popover:
+      title: 可調整大小的面板檢視
+      description: 透過調整面板檢視的大小來自訂工作區，以符合您的偏好。將<b>滑鼠懸停</b>在面板邊緣，直到出現調整大小的游標，再<b>點擊並拖曳</b>以調整面板大小。
+      prefferedSide: right
+
+MENU_TOUR:
+  - element: '#side-panel_tour'
+    popover:
+      title: 貼上選單面板
+      description: 此面板讓您管理系統工作列或選單列的原生貼上選單。<b>按住並拖曳</b>項目以重新排列，<b>雙擊</b>以重新命名。<b>按住</b> ALT 或 Command 鍵並點擊任意項目可多選。
+      prefferedSide: right
+  - element: '#menu-find_tour'
+    popover:
+      title: 尋找選單項目
+      description: 使用搜尋列快速找到特定的選單項目。輸入關鍵字以篩選並定位您需要的項目。
+      prefferedSide: bottom
+      alignment: center
+  - element: div[role=treeitem]
+    popover:
+      title: 選單項目樹狀結構
+      description: 選單樹狀結構中的每個項目都可以個別或以群組方式重新排列。<b>雙擊</b>以重新命名，<b>按住並拖曳</b>以重新排列。<b>按住</b> ALT 或 Command 鍵並點擊可多選。
+      prefferedSide: right
+  - element: '#tabs-menu_tour'
+    meta:
+      closeTourCssPosition: hidden
+    popover:
+      title: 歷史/選單導覽分頁
+      description: 在剪貼簿歷史與貼上選單之間切換，輕鬆管理並存取您的內容。
+      alignment: center
+      prefferedSide: top
+  - element: '#menu-icon-menu-button_tour'
+    meta:
+      closeTourCssPosition: hidden
+    popover:
+      title: 已選項目貼上選單
+      description: 使用此選單管理多個已選取的選單項目。多選、取消全選、重建原生選單，或刪除項目，以快速整理您的貼上選單。
+      alignment: end
+      prefferedSide: right
+  - element: '#menu-main-list_tour'
+    meta:
+      closeTourCssPosition: hidden
+    popover:
+      title: 管理貼上選單面板
+      description: 此面板讓您管理所有使用中的選單項目。新增、編輯或移除項目以自訂您的貼上選單。建立新項目或連結現有片段。<b>雙擊</b>可將內容複製至剪貼簿，<b>右鍵點擊</b>可查看更多選項。
+      alignment: start
+      prefferedSide: left
+  - element: .menu-item_tour
+    popover:
+      title: 選單項目
+      description: 在此您可以個別管理每個選單項目。<b>點擊</b>展開圖示以查看選單內容。<b>雙擊</b>可將內容複製至剪貼簿，<b>右鍵點擊</b>可查看更多選項。
+      alignment: center
+      prefferedSide: bottom
+  - element: '#add-menu-item__tour'
+    popover:
+      title: 新增選單項目
+      description: 點擊加號圖示，選擇要新增項目的位置，可在現有選單項目之前或之後加入。您可以建立新選單、子選單、分隔線、已停用的選單項目、來自最近歷史的選單項目，或連結至已儲存的片段。
+      alignment: end
+      prefferedSide: bottom
+  - element: '#toggle-inactive-menu-items_tour'
+    popover:
+      title: 切換未使用的選單項目
+      description: 點擊此圖示可顯示或隱藏未使用的選單項目。當需要時，專注於使用中的項目，有助於管理和整理您的選單。簡化選單並整頓工作區，提升工作效率。
+      alignment: start
+      prefferedSide: bottom
+  - element: .panel-resize_tour
+    popover:
+      title: 可調整大小的面板檢視
+      description: 透過調整面板檢視的大小來自訂工作區，以符合您的偏好。將<b>滑鼠懸停</b>在面板邊緣，直到出現調整大小的游標，再<b>點擊並拖曳</b>以調整面板大小。
+      prefferedSide: right
+
+NAVBAR_TOUR:
+  - element: '#navbar-panel_tour'
+    popover:
+      title: 導覽列
+      description: 導覽列提供快速存取 PasteBar 功能與設定的入口。使用它在剪貼簿歷史與貼上選單之間切換、存取您的收藏集、執行全域搜尋、切換已釘選看板的顯示狀態、調整設定，以及在需要時取得說明。
+      alignment: center
+      prefferedSide: bottom
+  - element: '#navbar-pastebar_tour'
+    popover:
+      title: PasteBar 選單
+      description: PasteBar 選單提供快速存取基本功能與資訊的入口。在此您可以檢查更新、存取設定、鎖定應用程式螢幕、關閉主視窗，或結束應用程式。
+      alignment: start
+      prefferedSide: bottom
+  - element: '#navbar-view_tour'
+    popover:
+      title: 檢視選單
+      description: 使用檢視選單在剪貼簿歷史和貼上選單之間導覽、調整選項、變更色彩主題、修改 UI 字型大小，以及變更語言。存取其他設定以獲得個人化體驗。
+      alignment: start
+      prefferedSide: bottom
+  - element: '#navbar-collections_tour'
+    popover:
+      title: 收藏集選單
+      description: 收藏集選單讓您在不同的片段、看板和分頁收藏集之間切換。建立並自訂每個收藏集以符合您的特定需求，例如依專案或類別整理內容。
+      alignment: center
+      prefferedSide: bottom
+  - element: '#navbar-toggle-history-split'
+    popover:
+      title: 切換歷史視窗
+      description: 點擊此圖示可在獨立的視窗中開啟或關閉剪貼簿歷史。使用此功能可獨立於主視窗管理您的剪貼簿歷史。
+      alignment: center
+      preferredSide: bottom
+  - element: '#navbar-search_tour'
+    popover:
+      title: 全域搜尋
+      description: 使用全域搜尋快速找到目前收藏集中的片段、看板和選單項目。輸入關鍵字篩選結果，有效率地定位您需要的內容。從搜尋結果中<b>雙擊</b>片段即可直接複製。
+      alignment: center
+      prefferedSide: bottom
+  - element: '#navbar-pinned_tour'
+    popover:
+      title: 切換已釘選看板
+      description: 點擊此圖示可顯示或隱藏已釘選的看板。使用此功能保持工作區整潔，並專注於最相關的內容。
+      alignment: end
+      prefferedSide: bottom
+  - element: '#navbar-help_tour'
+    popover:
+      title: 說明選單
+      description: 從說明選單快速存取導覽教學和 UI 功能展示。它提供逐步引導和示範，協助您有效瀏覽並了解 PasteBar 的功能和使用者介面。
+      alignment: end
+      prefferedSide: bottom
+  - element: '#navbar-close-window_tour'
+    popover:
+      title: 關閉主視窗
+      description: 點擊關閉圖示以關閉 PasteBar 主視窗，同時保持其功能可從工作列或選單列圖示存取。您隨時可以從主選單重新開啟主應用程式視窗。
+      alignment: end
+      prefferedSide: bottom
+
+SETTINGS_TOUR:
+  - element: '#app-settings-history_tour'
+    popover:
+      title: 剪貼簿歷史設定
+      description: 調整剪貼簿歷史設定，自訂 PasteBar 擷取和管理您所複製內容的方式。啟用或停用自動更新、自動加星號、連結預覽、停用詞清單，以及程式語言自動偵測等功能，以獲得個人化體驗。
+      alignment: start
+      prefferedSide: right
+  - element: '#app-settings-collections_tour'
+    popover:
+      title: 管理收藏集設定
+      description: 使用管理收藏集來整理和自訂您的收藏集。新增收藏集、編輯現有收藏集，並在它們之間切換以符合您的工作流程。透過將相關的片段、看板和分頁分組，有效率地管理您的內容。
+      alignment: start
+      prefferedSide: right
+  - element: '#app-settings-preferences_tour'
+    popover:
+      title: 使用者偏好設定
+      description: 調整字型大小、切換色彩主題、變更介面語言，以及設定自動啟動選項。切換面板版面配置、在導覽列上顯示收藏集名稱，以及管理片段筆記快顯視窗。
+      alignment: start
+      prefferedSide: right
+  - element: '#app-settings-security_tour'
+    popover:
+      title: 安全性設定
+      description: 設定安全性設定以保護您的資料。設定鎖定螢幕密碼和復原密碼。控制鎖定螢幕時的剪貼簿歷史擷取，並啟用閒置時自動鎖定。調整這些設定以增強 PasteBar 應用程式的安全性。
+      alignment: start
+      prefferedSide: right
+  - element: '#app-settings-back_tour'
+    popover:
+      title: 返回主畫面
+      description: 點擊以從設定返回主應用程式檢視。
+      alignment: start
+      prefferedSide: right

--- a/packages/pastebar-app-ui/src/locales/lang/zhTW/updater.yaml
+++ b/packages/pastebar-app-ui/src/locales/lang/zhTW/updater.yaml
@@ -1,0 +1,30 @@
+Check for Update: 檢查應用程式更新
+Checking for Update...: 正在檢查更新...
+Confirm Restart: 確認重新啟動
+Confirm Update: 確認更新
+Download Completed: 下載完成
+Download Completed Quit and Manually Install: 下載的更新檔案應會自動開啟。若要完成更新，請先結束 PasteBar 應用程式，再手動完成最新版本的安裝。安裝完成後，請使用更新後的版本啟動 PasteBar。
+Download Update: 下載更新
+Downloading...: 正在下載...
+General Update Error: 更新過程中發生錯誤。請稍後再試。若問題持續發生，請手動下載並安裝更新。
+Install Update: 安裝更新
+Installing Update: 正在安裝更新
+No Update Available: 目前沒有可用的更新
+Permission Denied Message: 由於權限不足，更新程式無法替換舊的應用程式檔案。請使用具有系統管理員權限的使用者帳號，手動下載並更新應用程式檔案。
+Quit PasteBar: 結束 PasteBar
+Release date {{date}}: 發布日期 {{date}}
+Remind Me Later: 稍後提醒我
+Restart: 重新啟動
+Restart Required: 需要重新啟動
+Restart to Finish: 重新啟動以完成更新
+Restart to Update: 重新啟動 PasteBar
+Skip Download: 略過下載
+Skip This Version: 略過此版本
+Try Install Again: 再試一次安裝
+Update Available: 有可用的更新
+Update Error: 更新錯誤
+Update Install Error: 更新安裝錯誤
+'Update: Permission Denied': '更新：存取被拒'
+Upgrade removes Pro features: 升級將移除專業版功能
+Version {{newVersion}} is available: 版本 {{newVersion}} 已可使用
+View Changes: 查看變更內容

--- a/packages/pastebar-app-ui/src/locales/languges.ts
+++ b/packages/pastebar-app-ui/src/locales/languges.ts
@@ -25,4 +25,5 @@ export const LANGUAGES: {
   },
   { code: 'uk', name: 'Українська', flag: '🇺🇦', website: 'www.pastebar.app' },
   { code: 'zhCN', name: '简体中文', flag: '🇨🇳', website: 'www.pastebar.app' },
+  { code: 'zhTW', name: '繁體中文', flag: '🇹🇼', website: 'www.pastebar.app' },
 ]

--- a/packages/pastebar-app-ui/src/locales/locales.ts
+++ b/packages/pastebar-app-ui/src/locales/locales.ts
@@ -33,6 +33,7 @@ export const timeAgoCache = new Map()
 // Define a mapping for non-dash language codes to the correct dash format
 const langCodeMapping: { [key: string]: string } = {
   zhCN: 'zh-CN',
+  zhTW: 'zh-TW',
   esES: 'es-ES',
 }
 

--- a/packages/pastebar-app-ui/src/styles/globals.css
+++ b/packages/pastebar-app-ui/src/styles/globals.css
@@ -618,6 +618,10 @@ body .simplified-layout .history-box {
     margin: 0;
     font-family:
       Inter,
+      'Microsoft JhengHei',
+      'PingFang TC',
+      'Noto Sans TC',
+      'Microsoft YaHei',
       -apple-system,
       BlinkMacSystemFont,
       'Segoe UI',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -190,7 +190,7 @@ module.exports = {
         sm: 'calc(var(--radius) - 4px)',
       },
       fontFamily: {
-        sans: ['Inter'],
+        sans: ['Inter', '"Microsoft JhengHei"', '"PingFang TC"', '"Noto Sans TC"', '"Microsoft YaHei"', 'sans-serif'],
       },
       keyframes: {
         'accordion-down': {


### PR DESCRIPTION
## What changed
Adds **Traditional Chinese (zh-TW)** support, fixes **CJK font rendering**, and fixes a **global-hotkey bug**.

### 1. Traditional Chinese (zh-TW) — feat(i18n)
- Register 繁體中文 (zh-TW) as a selectable language (`languges.ts`) and ship its locale folder (`src/locales/lang/zhTW`).
- Wire time-ago (`locales.ts`) and date-fns (`date-locales`) for zh-TW.

### 2. CJK font fallback — feat(i18n)
- The font stack was `Inter` only (Latin), so CJK characters fell back per-glyph to whatever system font, causing inconsistent stroke weights.
- Add `Microsoft JhengHei` / `PingFang TC` / `Noto Sans TC` to the sans stack (`globals.css` body + `tailwind.config.js`). This also improves the existing `zhCN` and `ja` locales.

### 3. Global hotkey not released on change — fix
- Changing a global hotkey registered the new shortcut without unregistering the old one, so the previous combo stayed grabbed system-wide until restart (e.g. setting `Ctrl+V` then changing it left `Ctrl+V` hijacked, breaking normal paste).
- Call `unregisterAll()` before (re)registering on the main window in `App.tsx`.

## How to test
- Pick 繁體中文 from the language menu → UI switches to Traditional Chinese, CJK text renders consistently.
- Set a global hotkey, then change it → the previous one is released without restarting the app.

## Notes
The zh-TW translation content has a companion PR to the translation repo: PasteBar/pastebar-localization#12

🤖 Generated with [Claude Code](https://claude.com/claude-code)
